### PR TITLE
feat: list roadside facilities

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { ContactPage } from "./pages/ContactPage";
 import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 import { TermsOfService } from "./pages/TermsOfService";
 import NotFound from "./pages/NotFound";
+import { RoadsidePage } from "./pages/RoadsidePage";
 
 const queryClient = new QueryClient();
 
@@ -29,6 +30,7 @@ const App = () => (
             <Route path="/" element={<SearchPage />} />
             <Route path="/results" element={<ResultsPage />} />
             <Route path="/provider/:id" element={<ProviderDetail />} />
+            <Route path="/roadside" element={<RoadsidePage />} />
             <Route path="/location-error" element={<LocationError />} />
             <Route path="/signup" element={<ProviderSignup />} />
             <Route path="/signup/success" element={<SignupSuccess />} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -66,6 +66,18 @@ interface ContactForm {
   message: string;
 }
 
+interface RoadsideFacility {
+  id: string;
+  name: string;
+  type: 'restaurant' | 'fuel' | 'parking';
+  address: string;
+  location: {
+    lat: number;
+    lon: number;
+  };
+  distance_km: number;
+}
+
 // Mock data for development
 const mockProviders: Provider[] = [
   {
@@ -130,6 +142,43 @@ const mockProviders: Provider[] = [
   }
 ];
 
+const mockRoadsideFacilities: Omit<RoadsideFacility, 'distance_km'>[] = [
+  {
+    id: 'r1',
+    name: 'رستوران بهار',
+    type: 'restaurant',
+    address: 'تهران، خیابان آزادی',
+    location: { lat: 35.7225, lon: 51.337 },
+  },
+  {
+    id: 'f1',
+    name: 'پمپ بنزین آزادی',
+    type: 'fuel',
+    address: 'تهران، بزرگراه شهید لشگری',
+    location: { lat: 35.7249, lon: 51.33 },
+  },
+  {
+    id: 'p1',
+    name: 'پارکینگ کامیونداران',
+    type: 'parking',
+    address: 'تهران، جاده مخصوص',
+    location: { lat: 35.73, lon: 51.35 },
+  },
+];
+
+function calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371; // km
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
 class ApiClient {
   private async request<T>(
     endpoint: string,
@@ -193,6 +242,22 @@ class ApiClient {
     return { success: true, data: results };
   }
 
+  // Search nearby roadside facilities like restaurants, fuel and parking
+  async searchRoadsideFacilities(
+    lat: number,
+    lon: number
+  ): Promise<ApiResponse<RoadsideFacility[]>> {
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    const facilities: RoadsideFacility[] = mockRoadsideFacilities.map(f => ({
+      ...f,
+      distance_km: calculateDistance(lat, lon, f.location.lat, f.location.lon),
+    }));
+
+    facilities.sort((a, b) => a.distance_km - b.distance_km);
+    return { success: true, data: facilities };
+  }
+
   // Get provider details
   async getProvider(id: string): Promise<ApiResponse<Provider>> {
     await new Promise(resolve => setTimeout(resolve, 300));
@@ -246,10 +311,13 @@ class ApiClient {
 export const api = new ApiClient();
 
 // Export convenience functions for direct use
-export const getProviders = (lat: number, lon: number, category?: ServiceCategory, vehicle?: VehicleType) => 
+export const getProviders = (lat: number, lon: number, category?: ServiceCategory, vehicle?: VehicleType) =>
   api.searchProviders(lat, lon, category, vehicle);
 
 export const getProvider = (id: string) => api.getProvider(id);
+
+export const getRoadsideFacilities = (lat: number, lon: number) =>
+  api.searchRoadsideFacilities(lat, lon);
 
 export const requestOTP = (phone: string) => api.requestOtp(phone);
 
@@ -260,4 +328,12 @@ export const createProvider = (data: ProviderRegistration, token?: string) =>
 
 export const submitContactForm = (data: ContactForm) => api.submitContact(data);
 
-export type { Provider, ProviderSearchResult, ServiceCategory, VehicleType, ProviderRegistration, ContactForm };
+export type {
+  Provider,
+  ProviderSearchResult,
+  ServiceCategory,
+  VehicleType,
+  ProviderRegistration,
+  ContactForm,
+  RoadsideFacility,
+};

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -67,6 +67,17 @@ export const ResultsPage: React.FC = () => {
   };
 
   const handleCategoryChange = (newCategory: ServiceCategory) => {
+    if (newCategory === 'roadside') {
+      const latParam = searchParams.get('lat');
+      const lonParam = searchParams.get('lon');
+      if (!latParam || !lonParam) {
+        navigate('/location-error');
+      } else {
+        navigate(`/roadside?lat=${latParam}&lon=${lonParam}`);
+      }
+      return;
+    }
+
     const newParams = new URLSearchParams(searchParams);
     newParams.set('category', newCategory);
     setSearchParams(newParams);

--- a/src/pages/RoadsidePage.tsx
+++ b/src/pages/RoadsidePage.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Header } from '@/components/Header';
+import { api, RoadsideFacility } from '@/lib/api';
+import { MapPin } from 'lucide-react';
+
+export const RoadsidePage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const lat = parseFloat(searchParams.get('lat') || '0');
+  const lon = parseFloat(searchParams.get('lon') || '0');
+  const [facilities, setFacilities] = useState<RoadsideFacility[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchFacilities = async () => {
+      setIsLoading(true);
+      const response = await api.searchRoadsideFacilities(lat, lon);
+      if (response.success && response.data) {
+        setFacilities(response.data);
+      } else {
+        setError(response.error || 'خطا در بارگذاری نتایج');
+      }
+      setIsLoading(false);
+    };
+    fetchFacilities();
+  }, [lat, lon]);
+
+  const openDirections = (facility: RoadsideFacility) => {
+    const url = `https://www.google.com/maps/dir/?api=1&origin=${lat},${lon}&destination=${facility.location.lat},${facility.location.lon}`;
+    window.open(url, '_blank');
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header title="خدمات جاده‌ای" />
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-muted-foreground">در حال بارگذاری...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header title="خدمات جاده‌ای" />
+        <div className="flex-1 flex items-center justify-center p-4">
+          <p className="text-destructive">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const groups = {
+    restaurant: facilities.filter(f => f.type === 'restaurant'),
+    fuel: facilities.filter(f => f.type === 'fuel'),
+    parking: facilities.filter(f => f.type === 'parking'),
+  };
+
+  const renderList = (items: RoadsideFacility[]) => (
+    <div className="space-y-2">
+      {items.map(item => (
+        <div
+          key={item.id}
+          className="bg-card p-4 rounded-lg shadow-card cursor-pointer hover:shadow-floating"
+          onClick={() => openDirections(item)}
+        >
+          <h3 className="font-semibold mb-1">{item.name}</h3>
+          <p className="text-sm text-muted-foreground mb-1">{item.address}</p>
+          <div className="flex items-center gap-1 text-sm text-primary">
+            <MapPin size={16} />
+            {item.distance_km.toFixed(1)} کیلومتر
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header title="خدمات جاده‌ای" />
+      <div className="flex-1 p-4 space-y-6">
+        {groups.restaurant.length > 0 && (
+          <div>
+            <h2 className="font-semibold mb-2">رستوران‌ها</h2>
+            {renderList(groups.restaurant)}
+          </div>
+        )}
+        {groups.fuel.length > 0 && (
+          <div>
+            <h2 className="font-semibold mb-2">جایگاه سوخت</h2>
+            {renderList(groups.fuel)}
+          </div>
+        )}
+        {groups.parking.length > 0 && (
+          <div>
+            <h2 className="font-semibold mb-2">پارکینگ</h2>
+            {renderList(groups.parking)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -23,6 +23,11 @@ export const SearchPage: React.FC = () => {
       lon: lon.toString(),
     });
 
+    if (selectedCategory === 'roadside') {
+      navigate(`/roadside?${params.toString()}`);
+      return;
+    }
+
     if (selectedCategory) {
       params.set('category', selectedCategory);
     }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -12,6 +12,22 @@ export const SearchPage: React.FC = () => {
   const { lat, lon, isLoading, error, requestLocation } = useLocation();
   const navigate = useNavigate();
 
+  const handleCategorySelect = (category: ServiceCategory) => {
+    if (category === 'roadside') {
+      if (!lat || !lon) {
+        navigate('/location-error');
+        return;
+      }
+      const params = new URLSearchParams({
+        lat: lat.toString(),
+        lon: lon.toString(),
+      });
+      navigate(`/roadside?${params.toString()}`);
+    } else {
+      setSelectedCategory(category);
+    }
+  };
+
   const handleSearch = () => {
     if (!lat || !lon) {
       navigate('/location-error');
@@ -22,11 +38,6 @@ export const SearchPage: React.FC = () => {
       lat: lat.toString(),
       lon: lon.toString(),
     });
-
-    if (selectedCategory === 'roadside') {
-      navigate(`/roadside?${params.toString()}`);
-      return;
-    }
 
     if (selectedCategory) {
       params.set('category', selectedCategory);
@@ -80,7 +91,7 @@ export const SearchPage: React.FC = () => {
           <h2 className="text-mobile-lg font-semibold mb-4">نوع خدمات مورد نیاز</h2>
           <CategorySelector
             selectedCategory={selectedCategory}
-            onCategorySelect={setSelectedCategory}
+            onCategorySelect={handleCategorySelect}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- route drivers to a new roadside facilities page when choosing خدمات جاده‌ای
- display nearby restaurants, fuel stations, and parking with links to map directions
- add API support and mock data for roadside facilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a2ecd464908328bcdb97081c6e8d2a