### PR TITLE
Rename roadside services menu

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -15,8 +15,8 @@ interface CategorySelectorProps {
 const categories = [
   {
     id: 'roadside' as ServiceCategory,
-    title: 'خدمات جاده‌ای',
-    description: 'پارکینگ، سوخت، رستوران',
+    title: 'فروش روغن و فیلتر',
+    description: 'انواع روغن، فیلتر و لوازم مصرفی',
     icon: Truck,
   },
   {

--- a/src/pages/RoadsidePage.tsx
+++ b/src/pages/RoadsidePage.tsx
@@ -34,7 +34,7 @@ export const RoadsidePage: React.FC = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen flex flex-col">
-        <Header title="خدمات جاده‌ای" />
+        <Header title="فروش روغن و فیلتر" />
         <div className="flex-1 flex items-center justify-center">
           <p className="text-muted-foreground">در حال بارگذاری...</p>
         </div>
@@ -45,7 +45,7 @@ export const RoadsidePage: React.FC = () => {
   if (error) {
     return (
       <div className="min-h-screen flex flex-col">
-        <Header title="خدمات جاده‌ای" />
+        <Header title="فروش روغن و فیلتر" />
         <div className="flex-1 flex items-center justify-center p-4">
           <p className="text-destructive">{error}</p>
         </div>
@@ -80,7 +80,7 @@ export const RoadsidePage: React.FC = () => {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <Header title="خدمات جاده‌ای" />
+      <Header title="فروش روغن و فیلتر" />
       <div className="flex-1 p-4 space-y-6">
         {groups.restaurant.length > 0 && (
           <div>


### PR DESCRIPTION
## Summary
- rename roadside services menu to oil and filter sales
- update roadside page header accordingly

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68a5ec8c748c8328970efce5e187208b