### PR TITLE
feat: add city and county selection

### DIFF
--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem
+} from '@/components/ui/select';
+import { cities } from '@/data/locations';
+
+interface LocationSelectorProps {
+  city?: string;
+  county?: string;
+  onCityChange: (value: string) => void;
+  onCountyChange: (value: string) => void;
+}
+
+export const LocationSelector: React.FC<LocationSelectorProps> = ({
+  city,
+  county,
+  onCityChange,
+  onCountyChange,
+}) => {
+  const selectedCity = cities.find(c => c.name === city);
+
+  return (
+    <div className="space-y-3">
+      <Select
+        value={city || ''}
+        onValueChange={(value) => {
+          onCityChange(value);
+          onCountyChange('');
+        }}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="انتخاب شهر" />
+        </SelectTrigger>
+        <SelectContent>
+          {cities.map(c => (
+            <SelectItem key={c.name} value={c.name}>
+              {c.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {city && (
+        <Select value={county || ''} onValueChange={onCountyChange}>
+          <SelectTrigger>
+            <SelectValue placeholder="انتخاب شهرستان" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">همه شهرستان‌ها</SelectItem>
+            {selectedCity?.counties.map(cnt => (
+              <SelectItem key={cnt} value={cnt}>
+                {cnt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  );
+};

--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -1,0 +1,19 @@
+export interface City {
+  name: string;
+  counties: string[];
+}
+
+export const cities: City[] = [
+  {
+    name: 'تهران',
+    counties: ['تهران', 'کرج', 'شهریار', 'ورامین']
+  },
+  {
+    name: 'اصفهان',
+    counties: ['اصفهان']
+  },
+  {
+    name: 'تبریز',
+    counties: ['تبریز']
+  }
+];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,6 +21,8 @@ interface Provider {
   radius_km: number;
   is_24_7: boolean;
   vehicle_types: VehicleType[];
+  city: string;
+  county: string;
 }
 
 interface ProviderSearchResult {
@@ -33,6 +35,8 @@ interface ProviderSearchResult {
   vehicle_types: VehicleType[];
   radius_km: number;
   categories: ServiceCategory[];
+  city: string;
+  county: string;
 }
 
 type ServiceCategory = 'roadside' | 'tire' | 'recovery';
@@ -79,7 +83,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7219, lon: 51.3347 },
     radius_km: 60,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi']
+    vehicle_types: ['truck', 'semi'],
+    city: 'تهران',
+    county: 'تهران'
   },
   {
     id: '2',
@@ -91,7 +97,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7419, lon: 51.3047 },
     radius_km: 45,
     is_24_7: false,
-    vehicle_types: ['truck', 'bus']
+    vehicle_types: ['truck', 'bus'],
+    city: 'تهران',
+    county: 'کرج'
   },
   {
     id: '3',
@@ -103,7 +111,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6719, lon: 51.2747 },
     radius_km: 30,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi', 'bus']
+    vehicle_types: ['truck', 'semi', 'bus'],
+    city: 'تهران',
+    county: 'ساوه'
   },
   {
     id: '4',
@@ -115,7 +125,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6919, lon: 51.2647 },
     radius_km: 80,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi']
+    vehicle_types: ['truck', 'semi'],
+    city: 'تهران',
+    county: 'کرج'
   },
   {
     id: '5',
@@ -127,7 +139,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.8019, lon: 51.1547 },
     radius_km: 25,
     is_24_7: false,
-    vehicle_types: ['truck']
+    vehicle_types: ['truck'],
+    city: 'تهران',
+    county: 'قدس'
   },
   {
     id: '6',
@@ -139,7 +153,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7319, lon: 51.1947 },
     radius_km: 50,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi', 'bus']
+    vehicle_types: ['truck', 'semi', 'bus'],
+    city: 'اصفهان',
+    county: 'اصفهان'
   },
   {
     id: '7',
@@ -151,7 +167,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6419, lon: 51.2347 },
     radius_km: 40,
     is_24_7: false,
-    vehicle_types: ['truck', 'semi']
+    vehicle_types: ['truck', 'semi'],
+    city: 'تهران',
+    county: 'کرج'
   },
   {
     id: '8',
@@ -163,7 +181,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7519, lon: 51.2847 },
     radius_km: 35,
     is_24_7: false,
-    vehicle_types: ['truck', 'bus']
+    vehicle_types: ['truck', 'bus'],
+    city: 'تهران',
+    county: 'شهریار'
   },
   {
     id: '9',
@@ -175,7 +195,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7819, lon: 51.3647 },
     radius_km: 20,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi', 'bus']
+    vehicle_types: ['truck', 'semi', 'bus'],
+    city: 'تهران',
+    county: 'تهران'
   },
   {
     id: '10',
@@ -187,7 +209,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6119, lon: 51.3947 },
     radius_km: 55,
     is_24_7: false,
-    vehicle_types: ['bus']
+    vehicle_types: ['bus'],
+    city: 'تهران',
+    county: 'ورامین'
   }
 ];
 
@@ -222,20 +246,29 @@ class ApiClient {
 
   // Search providers by location and category
   async searchProviders(
-    lat: number,
-    lon: number,
+    lat?: number,
+    lon?: number,
     category?: ServiceCategory,
-    vehicle?: VehicleType
+    vehicle?: VehicleType,
+    city?: string,
+    county?: string
   ): Promise<ApiResponse<ProviderSearchResult[]>> {
     // Mock implementation for development
     await new Promise(resolve => setTimeout(resolve, 500)); // Simulate network delay
     
     let filteredProviders = mockProviders;
     
+    if (city) {
+      filteredProviders = filteredProviders.filter(p => p.city === city);
+      if (county) {
+        filteredProviders = filteredProviders.filter(p => p.county === county);
+      }
+    }
+
     if (category) {
       filteredProviders = filteredProviders.filter(p => p.categories.includes(category));
     }
-    
+
     if (vehicle) {
       filteredProviders = filteredProviders.filter(p => p.vehicle_types.includes(vehicle));
     }
@@ -249,7 +282,9 @@ class ApiClient {
       is_24_7: p.is_24_7,
       vehicle_types: p.vehicle_types,
       radius_km: p.radius_km,
-      categories: p.categories
+      categories: p.categories,
+      city: p.city,
+      county: p.county
     }));
 
     return { success: true, data: results };

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -4,6 +4,7 @@ import { Header } from '@/components/Header';
 import { CategorySelector } from '@/components/CategorySelector';
 import { VehicleFilter } from '@/components/VehicleFilter';
 import { ProviderCard } from '@/components/ProviderCard';
+import { LocationSelector } from '@/components/LocationSelector';
 import { Button } from '@/components/ui/button';
 import { api, ProviderSearchResult, ServiceCategory, VehicleType } from '@/lib/api';
 import { RefreshCw, MapPin, LoaderCircle } from 'lucide-react';
@@ -25,15 +26,17 @@ export const ResultsPage: React.FC = () => {
   const lon = parseFloat(searchParams.get('lon') || '0');
   const category = searchParams.get('category') as ServiceCategory | null;
   const vehicle = searchParams.get('vehicle') as VehicleType | 'all' | null;
+  const city = searchParams.get('city') || undefined;
+  const county = searchParams.get('county') || undefined;
 
   useEffect(() => {
-    if (!lat || !lon) {
+    if ((!lat || !lon) && !city) {
       navigate('/location-error');
       return;
     }
 
     fetchProviders();
-  }, [lat, lon, category]);
+  }, [lat, lon, category, city, county]);
 
   useEffect(() => {
     applyFilters();
@@ -43,7 +46,14 @@ export const ResultsPage: React.FC = () => {
     setIsLoading(true);
     setError(null);
 
-    const response = await api.searchProviders(lat, lon, category || undefined);
+    const response = await api.searchProviders(
+      lat || undefined,
+      lon || undefined,
+      category || undefined,
+      undefined,
+      city,
+      county
+    );
     
     if (response.success && response.data) {
       setAllProviders(response.data);
@@ -78,6 +88,27 @@ export const ResultsPage: React.FC = () => {
       newParams.delete('vehicle');
     } else {
       newParams.set('vehicle', newVehicle);
+    }
+    setSearchParams(newParams);
+  };
+
+  const handleCityChange = (newCity: string) => {
+    const newParams = new URLSearchParams(searchParams);
+    if (newCity) {
+      newParams.set('city', newCity);
+    } else {
+      newParams.delete('city');
+    }
+    newParams.delete('county');
+    setSearchParams(newParams);
+  };
+
+  const handleCountyChange = (newCounty: string) => {
+    const newParams = new URLSearchParams(searchParams);
+    if (newCounty) {
+      newParams.set('county', newCounty);
+    } else {
+      newParams.delete('county');
     }
     setSearchParams(newParams);
   };
@@ -124,6 +155,12 @@ export const ResultsPage: React.FC = () => {
       {/* Filter Bar */}
       <div className="sticky top-16 z-40 bg-background/95 backdrop-blur-sm border-b p-4">
         <div className="space-y-3">
+          <LocationSelector
+            city={city}
+            county={county}
+            onCityChange={handleCityChange}
+            onCountyChange={handleCountyChange}
+          />
           <CategorySelector
             selectedCategory={category || undefined}
             onCategorySelect={handleCategoryChange}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -3,12 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { CategorySelector } from '@/components/CategorySelector';
 import { Footer } from '@/components/Footer';
+import { LocationSelector } from '@/components/LocationSelector';
 import { useLocation } from '@/contexts/LocationContext';
 import { ServiceCategory } from '@/lib/api';
 import { MapPin, Search, Truck } from 'lucide-react';
 
 export const SearchPage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<ServiceCategory | undefined>();
+  const [city, setCity] = useState<string | undefined>();
+  const [county, setCounty] = useState<string | undefined>();
   const { lat, lon, isLoading, error, requestLocation } = useLocation();
   const navigate = useNavigate();
 
@@ -27,9 +30,21 @@ export const SearchPage: React.FC = () => {
   };
 
   const handleSearch = () => {
-    if (!lat || !lon) {
+    if (!hasLocation && !city) {
       navigate('/location-error');
       return;
+    }
+
+    const params = new URLSearchParams();
+    if (lat && lon) {
+      params.set('lat', lat.toString());
+      params.set('lon', lon.toString());
+    }
+    if (city) {
+      params.set('city', city);
+    }
+    if (county) {
+      params.set('county', county);
     }
 
     if (selectedCategory) {
@@ -38,17 +53,14 @@ export const SearchPage: React.FC = () => {
         tire: 'tyre-wheel',
         recovery: 'recovery-accident'
       };
-      navigate(`/c/${slugMap[selectedCategory]}`);
+      navigate(`/c/${slugMap[selectedCategory]}?${params.toString()}`);
     } else {
-      const params = new URLSearchParams({
-        lat: lat.toString(),
-        lon: lon.toString(),
-      });
       navigate(`/results?${params.toString()}`);
     }
   };
 
   const hasLocation = lat && lon;
+  const canSearch = hasLocation || city;
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -88,6 +100,20 @@ export const SearchPage: React.FC = () => {
           )}
         </div>
 
+        {/* Location Selection */}
+        <div>
+          <h2 className="text-mobile-lg font-semibold mb-4">موقعیت</h2>
+          <LocationSelector
+            city={city}
+            county={county}
+            onCityChange={(c) => {
+              setCity(c);
+              setCounty(undefined);
+            }}
+            onCountyChange={setCounty}
+          />
+        </div>
+
         {/* Category Selection */}
         <div>
           <h2 className="text-mobile-lg font-semibold mb-4">نوع خدمات مورد نیاز</h2>
@@ -102,7 +128,7 @@ export const SearchPage: React.FC = () => {
         {/* Search Button */}
         <Button
           onClick={handleSearch}
-          disabled={!hasLocation || isLoading}
+          disabled={!canSearch || isLoading}
           className="w-full"
           size="lg"
           variant="hero"


### PR DESCRIPTION
## Summary
- allow choosing city then county via new LocationSelector
- filter provider search results based on selected city/county
- support manual location selection on search and results pages

## Testing
- `npm run lint` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a61987fc9c83289b2490d6388d77cc