### PR TITLE
Add oil sale page with city and county selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ContactPage } from "./pages/ContactPage";
 import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 import { TermsOfService } from "./pages/TermsOfService";
 import NotFound from "./pages/NotFound";
+import { OilSalePage } from "./pages/OilSalePage";
 
 const queryClient = new QueryClient();
 
@@ -38,6 +39,7 @@ const App = () => (
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/legal/privacy" element={<PrivacyPolicy />} />
             <Route path="/legal/terms" element={<TermsOfService />} />
+            <Route path="/oil-sale" element={<OilSalePage />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ServiceCategory } from '@/lib/api';
-import { Truck, Settings, AlertTriangle } from 'lucide-react';
+import { Truck, Settings, AlertTriangle, Droplet } from 'lucide-react';
 
 interface CategorySelectorProps {
   selectedCategory?: ServiceCategory;
@@ -32,6 +32,12 @@ const categories = [
     title: 'امداد و حادثه',
     description: 'یدک‌کش و تعمیرات اضطراری',
     icon: AlertTriangle,
+  },
+  {
+    id: 'oil' as ServiceCategory,
+    title: 'فروش روغن',
+    description: 'عرضه انواع روغن خودرو',
+    icon: Droplet,
   },
 ];
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -35,7 +35,7 @@ interface ProviderSearchResult {
   categories: ServiceCategory[];
 }
 
-type ServiceCategory = 'roadside' | 'tire' | 'recovery';
+type ServiceCategory = 'roadside' | 'tire' | 'recovery' | 'oil';
 type VehicleType = 'truck' | 'semi' | 'bus';
 
 interface OtpRequest {

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -103,12 +103,17 @@ export const CategoryPage: React.FC = () => {
   };
 
   const handleCategoryChange = (newCategory: ServiceCategory) => {
+    if (newCategory === 'oil') {
+      navigate('/oil-sale');
+      return;
+    }
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil: 'oil-sale'
     };
-    
+
     navigate(`/c/${slugMap[newCategory]}`);
   };
 

--- a/src/pages/OilSalePage.tsx
+++ b/src/pages/OilSalePage.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { Header } from '@/components/Header';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+
+interface OilProvider {
+  id: string;
+  name: string;
+  phone: string;
+  address: string;
+  city: string;
+  county: string;
+}
+
+const oilProviders: Record<string, Record<string, OilProvider[]>> = {
+  'تهران': {
+    'تهران': [
+      { id: '1', name: 'فروش روغن پارس', phone: '0211111111', address: 'تهران، خیابان انقلاب', city: 'تهران', county: 'تهران' },
+    ],
+    'ری': [
+      { id: '2', name: 'نمایندگی روغن ری', phone: '0212222222', address: 'ری، میدان شهرری', city: 'تهران', county: 'ری' },
+    ],
+  },
+  'اصفهان': {
+    'اصفهان': [
+      { id: '3', name: 'روغن فروشی اصفهان', phone: '0313333333', address: 'اصفهان، میدان نقش جهان', city: 'اصفهان', county: 'اصفهان' },
+    ],
+    'کاشان': [
+      { id: '4', name: 'روغن کاشان', phone: '0314444444', address: 'کاشان، خیابان امیرکبیر', city: 'اصفهان', county: 'کاشان' },
+    ],
+  },
+};
+
+export const OilSalePage: React.FC = () => {
+  const [selectedCity, setSelectedCity] = useState<string>('');
+  const [selectedCounty, setSelectedCounty] = useState<string>('');
+
+  const cities = Object.keys(oilProviders);
+  const counties = selectedCity ? Object.keys(oilProviders[selectedCity]) : [];
+
+  let providers: OilProvider[] = [];
+  if (selectedCity) {
+    if (selectedCounty) {
+      providers = oilProviders[selectedCity][selectedCounty];
+    } else {
+      providers = Object.values(oilProviders[selectedCity]).flat();
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header title="فروش روغن" />
+      <div className="p-4 space-y-4">
+        <div className="grid gap-4">
+          <Select onValueChange={(value) => { setSelectedCity(value); setSelectedCounty(''); }}>
+            <SelectTrigger>
+              <SelectValue placeholder="انتخاب شهر" />
+            </SelectTrigger>
+            <SelectContent>
+              {cities.map((city) => (
+                <SelectItem key={city} value={city}>
+                  {city}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {selectedCity && (
+            <Select onValueChange={setSelectedCounty}>
+              <SelectTrigger>
+                <SelectValue placeholder="انتخاب شهرستان" />
+              </SelectTrigger>
+              <SelectContent>
+                {counties.map((county) => (
+                  <SelectItem key={county} value={county}>
+                    {county}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          {providers.map((provider) => (
+            <div key={provider.id} className="bg-card p-4 rounded-lg shadow-card border">
+              <h3 className="font-semibold mb-2">{provider.name}</h3>
+              <p className="text-sm text-muted-foreground mb-1">{provider.address}</p>
+              <p className="text-sm">تلفن: {provider.phone}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OilSalePage;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -13,6 +13,10 @@ export const SearchPage: React.FC = () => {
   const navigate = useNavigate();
 
   const handleDirectNavigation = (category: ServiceCategory) => {
+    if (category === 'oil') {
+      navigate('/oil-sale');
+      return;
+    }
     if (!lat || !lon) {
       navigate('/location-error');
       return;
@@ -21,12 +25,17 @@ export const SearchPage: React.FC = () => {
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil: 'oil-sale'
     };
     navigate(`/c/${slugMap[category]}`);
   };
 
   const handleSearch = () => {
+    if (selectedCategory === 'oil') {
+      navigate('/oil-sale');
+      return;
+    }
     if (!lat || !lon) {
       navigate('/location-error');
       return;
@@ -36,7 +45,8 @@ export const SearchPage: React.FC = () => {
       const slugMap: Record<ServiceCategory, string> = {
         roadside: 'roadside',
         tire: 'tyre-wheel',
-        recovery: 'recovery-accident'
+        recovery: 'recovery-accident',
+        oil: 'oil-sale'
       };
       navigate(`/c/${slugMap[selectedCategory]}`);
     } else {
@@ -102,7 +112,7 @@ export const SearchPage: React.FC = () => {
         {/* Search Button */}
         <Button
           onClick={handleSearch}
-          disabled={!hasLocation || isLoading}
+          disabled={selectedCategory !== 'oil' && (!hasLocation || isLoading)}
           className="w-full"
           size="lg"
           variant="hero"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add oil sale service category and navigation
- create oil sale page with city and county filters
- fix lint by converting empty interfaces and using ESM tailwind plugin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a634f65a508328af2abd430289df17