### PR TITLE
feat: add city filter for oil providers

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ServiceCategory } from '@/lib/api';
-import { Truck, Settings, AlertTriangle } from 'lucide-react';
+import { Truck, Settings, AlertTriangle, Droplet } from 'lucide-react';
 
 interface CategorySelectorProps {
   selectedCategory?: ServiceCategory;
@@ -32,6 +32,12 @@ const categories = [
     title: 'امداد و حادثه',
     description: 'یدک‌کش و تعمیرات اضطراری',
     icon: AlertTriangle,
+  },
+  {
+    id: 'oil_filter' as ServiceCategory,
+    title: 'فروش روغن و فیلتر',
+    description: 'عرضه انواع روغن و فیلتر',
+    icon: Droplet,
   },
 ];
 

--- a/src/components/CityFilter.tsx
+++ b/src/components/CityFilter.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { MapPin } from 'lucide-react';
+
+interface CityFilterProps {
+  cities: string[];
+  value?: string;
+  onValueChange: (value: string) => void;
+}
+
+export const CityFilter: React.FC<CityFilterProps> = ({ cities, value = 'all', onValueChange }) => {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <MapPin size={16} className="text-muted-foreground flex-shrink-0" />
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger className="w-full min-w-[120px] h-9 text-sm">
+          <SelectValue placeholder="انتخاب شهر" />
+        </SelectTrigger>
+        <SelectContent className="bg-card border border-border">
+          <SelectItem value="all" className="hover:bg-accent">همه شهرها</SelectItem>
+          {cities.map((city) => (
+            <SelectItem key={city} value={city} className="hover:bg-accent">
+              {city}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -12,6 +12,7 @@ interface Provider {
   name: string;
   phone: string;
   address: string;
+  city: string;
   distance_km: number;
   categories: ServiceCategory[];
   location: {
@@ -28,6 +29,7 @@ interface ProviderSearchResult {
   name: string;
   phone: string;
   address: string;
+  city: string;
   distance_km: number;
   is_24_7: boolean;
   vehicle_types: VehicleType[];
@@ -35,7 +37,7 @@ interface ProviderSearchResult {
   categories: ServiceCategory[];
 }
 
-type ServiceCategory = 'roadside' | 'tire' | 'recovery';
+type ServiceCategory = 'roadside' | 'tire' | 'recovery' | 'oil_filter';
 type VehicleType = 'truck' | 'semi' | 'bus';
 
 interface OtpRequest {
@@ -74,6 +76,7 @@ const mockProviders: Provider[] = [
     name: 'امداد جاده‌ای آریا',
     phone: '+989121234567',
     address: 'تهران–قم، کیلومتر ۲۵',
+    city: 'تهران',
     distance_km: 3.2,
     categories: ['recovery'],
     location: { lat: 35.7219, lon: 51.3347 },
@@ -86,6 +89,7 @@ const mockProviders: Provider[] = [
     name: 'خدمات لاستیک پارس',
     phone: '+989129876543',
     address: 'اتوبان کرج، نبش خیابان آزادی',
+    city: 'کرج',
     distance_km: 7.8,
     categories: ['tire'],
     location: { lat: 35.7419, lon: 51.3047 },
@@ -98,6 +102,7 @@ const mockProviders: Provider[] = [
     name: 'پارکینگ و رستوران سروش',
     phone: '+989125557890',
     address: 'جاده ساوه، کیلومتر ۱۵',
+    city: 'تهران',
     distance_km: 12.5,
     categories: ['roadside'],
     location: { lat: 35.6719, lon: 51.2747 },
@@ -110,6 +115,7 @@ const mockProviders: Provider[] = [
     name: 'یدک‌کش شبانه‌روزی احمد',
     phone: '+989123456789',
     address: 'بزرگراه آزادگان، خروجی کرج',
+    city: 'تهران',
     distance_km: 5.1,
     categories: ['recovery'],
     location: { lat: 35.6919, lon: 51.2647 },
@@ -122,6 +128,7 @@ const mockProviders: Provider[] = [
     name: 'تعمیرگاه لاستیک شریف',
     phone: '+989127654321',
     address: 'شهر قدس، خیابان امام خمینی',
+    city: 'شهرقدس',
     distance_km: 8.9,
     categories: ['tire'],
     location: { lat: 35.8019, lon: 51.1547 },
@@ -134,6 +141,7 @@ const mockProviders: Provider[] = [
     name: 'مجتمع خدماتی بهشت',
     phone: '+989132223333',
     address: 'جاده اصفهان، کیلومتر ۴۵',
+    city: 'تهران',
     distance_km: 15.2,
     categories: ['roadside'],
     location: { lat: 35.7319, lon: 51.1947 },
@@ -146,6 +154,7 @@ const mockProviders: Provider[] = [
     name: 'امداد سریع کامیون',
     phone: '+989111112222',
     address: 'اتوبان کرج–قزوین، استراحتگاه مهرشهر',
+    city: 'کرج',
     distance_km: 22.0,
     categories: ['recovery'],
     location: { lat: 35.6419, lon: 51.2347 },
@@ -158,6 +167,7 @@ const mockProviders: Provider[] = [
     name: 'لاستیک فروشی رضا',
     phone: '+989144445555',
     address: 'شهریار، میدان امام حسین',
+    city: 'شهریار',
     distance_km: 11.7,
     categories: ['tire'],
     location: { lat: 35.7519, lon: 51.2847 },
@@ -170,6 +180,7 @@ const mockProviders: Provider[] = [
     name: 'جایگاه سوخت و پارکینگ ملی',
     phone: '+989155556666',
     address: 'آزادراه تهران–شمال، کیلومتر ۳۲',
+    city: 'تهران',
     distance_km: 18.4,
     categories: ['roadside'],
     location: { lat: 35.7819, lon: 51.3647 },
@@ -182,12 +193,39 @@ const mockProviders: Provider[] = [
     name: 'خدمات اتوبوسی آسمان',
     phone: '+989166667777',
     address: 'ورامین، خیابان شهید بهشتی',
+    city: 'ورامین',
     distance_km: 25.3,
     categories: ['roadside', 'tire'],
     location: { lat: 35.6119, lon: 51.3947 },
     radius_km: 55,
     is_24_7: false,
     vehicle_types: ['bus']
+  },
+  {
+    id: '11',
+    name: 'فروشگاه روغن پارسیان',
+    phone: '+989177778888',
+    address: 'تهران، خیابان ولیعصر',
+    city: 'تهران',
+    distance_km: 4.5,
+    categories: ['oil_filter'],
+    location: { lat: 35.715, lon: 51.4 },
+    radius_km: 15,
+    is_24_7: false,
+    vehicle_types: ['truck', 'semi', 'bus']
+  },
+  {
+    id: '12',
+    name: 'روغن و فیلتر قزوین',
+    phone: '+989188889999',
+    address: 'قزوین، بلوار اصلی',
+    city: 'قزوین',
+    distance_km: 50.0,
+    categories: ['oil_filter'],
+    location: { lat: 36.27, lon: 50.0 },
+    radius_km: 20,
+    is_24_7: false,
+    vehicle_types: ['truck']
   }
 ];
 
@@ -245,6 +283,7 @@ class ApiClient {
       name: p.name,
       phone: p.phone,
       address: p.address,
+      city: p.city,
       distance_km: p.distance_km,
       is_24_7: p.is_24_7,
       vehicle_types: p.vehicle_types,

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Header } from '@/components/Header';
 import { CategorySelector } from '@/components/CategorySelector';
 import { VehicleFilter } from '@/components/VehicleFilter';
+import { CityFilter } from '@/components/CityFilter';
 import { ProviderCard } from '@/components/ProviderCard';
 import { Button } from '@/components/ui/button';
 import { api, ProviderSearchResult, ServiceCategory, VehicleType } from '@/lib/api';
@@ -35,6 +36,12 @@ const categoryMap: Record<string, CategoryInfo> = {
     title: 'امداد و حادثه',
     subtitle: 'یدک‌کش و امداد جاده‌ای',
     subcategories: ['یدک‌کش', 'امداد', 'جرثقیل']
+  },
+  'oil-filter': {
+    id: 'oil_filter',
+    title: 'فروش روغن و فیلتر',
+    subtitle: 'عرضه انواع روغن و فیلتر',
+    subcategories: ['روغن موتور', 'فیلتر هوا', 'فیلتر روغن']
   }
 };
 
@@ -50,6 +57,8 @@ export const CategoryPage: React.FC = () => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedVehicle, setSelectedVehicle] = useState<VehicleType | 'all'>('all');
+  const [selectedCity, setSelectedCity] = useState<string>('all');
+  const [cities, setCities] = useState<string[]>([]);
 
   const categoryInfo = slug ? categoryMap[slug] : null;
 
@@ -68,8 +77,8 @@ export const CategoryPage: React.FC = () => {
   }, [lat, lon, categoryInfo]);
 
   useEffect(() => {
-    applyVehicleFilter();
-  }, [selectedVehicle, providers]);
+    applyFilters();
+  }, [selectedVehicle, selectedCity, providers]);
 
   const fetchProviders = async () => {
     if (!categoryInfo) return;
@@ -83,6 +92,8 @@ export const CategoryPage: React.FC = () => {
       // Sort by distance
       const sortedProviders = response.data.sort((a, b) => a.distance_km - b.distance_km);
       setProviders(sortedProviders);
+      const uniqueCities = Array.from(new Set(response.data.map(p => p.city)));
+      setCities(uniqueCities);
     } else {
       setError(response.error || 'خطا در بارگذاری نتایج');
     }
@@ -90,15 +101,19 @@ export const CategoryPage: React.FC = () => {
     setIsLoading(false);
   };
 
-  const applyVehicleFilter = () => {
+  const applyFilters = () => {
     let filtered = providers;
-    
+
     if (selectedVehicle && selectedVehicle !== 'all') {
-      filtered = providers.filter(provider => 
+      filtered = filtered.filter(provider =>
         provider.vehicle_types.includes(selectedVehicle as VehicleType)
       );
     }
-    
+
+    if (selectedCity && selectedCity !== 'all') {
+      filtered = filtered.filter(provider => provider.city === selectedCity);
+    }
+
     setFilteredProviders(filtered);
   };
 
@@ -106,7 +121,8 @@ export const CategoryPage: React.FC = () => {
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil_filter: 'oil-filter'
     };
     
     navigate(`/c/${slugMap[newCategory]}`);
@@ -168,8 +184,17 @@ export const CategoryPage: React.FC = () => {
             onCategorySelect={handleCategoryChange}
             variant="compact"
           />
-          <div className="flex items-center gap-3">
-            <div className="flex-1">
+          <div className="flex items-center gap-3 flex-wrap">
+            {categoryInfo.id === 'oil_filter' && cities.length > 0 && (
+              <div className="flex-1 min-w-[120px]">
+                <CityFilter
+                  cities={cities}
+                  value={selectedCity}
+                  onValueChange={setSelectedCity}
+                />
+              </div>
+            )}
+            <div className="flex-1 min-w-[120px]">
               <VehicleFilter
                 value={selectedVehicle}
                 onValueChange={setSelectedVehicle}

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Header } from '@/components/Header';
 import { CategorySelector } from '@/components/CategorySelector';
 import { VehicleFilter } from '@/components/VehicleFilter';
+import { CityFilter } from '@/components/CityFilter';
 import { ProviderCard } from '@/components/ProviderCard';
 import { Button } from '@/components/ui/button';
 import { api, ProviderSearchResult, ServiceCategory, VehicleType } from '@/lib/api';
@@ -20,6 +21,8 @@ export const ResultsPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectedCity, setSelectedCity] = useState<string>('all');
+  const [cities, setCities] = useState<string[]>([]);
 
   const lat = parseFloat(searchParams.get('lat') || '0');
   const lon = parseFloat(searchParams.get('lon') || '0');
@@ -37,7 +40,7 @@ export const ResultsPage: React.FC = () => {
 
   useEffect(() => {
     applyFilters();
-  }, [vehicle, allProviders]);
+  }, [vehicle, selectedCity, allProviders]);
 
   const fetchProviders = async () => {
     setIsLoading(true);
@@ -47,6 +50,8 @@ export const ResultsPage: React.FC = () => {
     
     if (response.success && response.data) {
       setAllProviders(response.data);
+      const uniqueCities = Array.from(new Set(response.data.map(p => p.city)));
+      setCities(uniqueCities);
     } else {
       setError(response.error || 'خطا در بارگذاری نتایج');
     }
@@ -58,11 +63,15 @@ export const ResultsPage: React.FC = () => {
     let filtered = allProviders;
     
     if (vehicle && vehicle !== 'all') {
-      filtered = allProviders.filter(provider => 
+      filtered = filtered.filter(provider =>
         provider.vehicle_types.includes(vehicle as VehicleType)
       );
     }
-    
+
+    if (selectedCity && selectedCity !== 'all') {
+      filtered = filtered.filter(p => p.city === selectedCity);
+    }
+
     setProviders(filtered);
   };
 
@@ -124,13 +133,22 @@ export const ResultsPage: React.FC = () => {
       {/* Filter Bar */}
       <div className="sticky top-16 z-40 bg-background/95 backdrop-blur-sm border-b p-4">
         <div className="space-y-3">
-          <CategorySelector
-            selectedCategory={category || undefined}
-            onCategorySelect={handleCategoryChange}
-            variant="compact"
-          />
-          <div className="flex items-center gap-3">
-            <div className="flex-1">
+      <CategorySelector
+        selectedCategory={category || undefined}
+        onCategorySelect={handleCategoryChange}
+        variant="compact"
+      />
+          <div className="flex items-center gap-3 flex-wrap">
+            {category === 'oil_filter' && cities.length > 0 && (
+              <div className="flex-1 min-w-[120px]">
+                <CityFilter
+                  cities={cities}
+                  value={selectedCity}
+                  onValueChange={setSelectedCity}
+                />
+              </div>
+            )}
+            <div className="flex-1 min-w-[120px]">
               <VehicleFilter
                 value={(vehicle as VehicleType) || 'all'}
                 onValueChange={handleVehicleChange}
@@ -147,8 +165,8 @@ export const ResultsPage: React.FC = () => {
               {isRefreshing ? 'در حال به‌روزرسانی...' : 'به‌روزرسانی موقعیت'}
             </Button>
           </div>
-        </div>
       </div>
+    </div>
 
       {/* Results */}
       <div className="flex-1 p-4">

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -21,7 +21,8 @@ export const SearchPage: React.FC = () => {
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil_filter: 'oil-filter'
     };
     navigate(`/c/${slugMap[category]}`);
   };
@@ -36,7 +37,8 @@ export const SearchPage: React.FC = () => {
       const slugMap: Record<ServiceCategory, string> = {
         roadside: 'roadside',
         tire: 'tyre-wheel',
-        recovery: 'recovery-accident'
+        recovery: 'recovery-accident',
+        oil_filter: 'oil-filter'
       };
       navigate(`/c/${slugMap[selectedCategory]}`);
     } else {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add "فروش روغن و فیلتر" category with city selection
- include city field and sample oil providers in API mock data
- support filtering by city on category and results pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing repository lint errors)*
- `npx eslint src/components/CategorySelector.tsx src/lib/api.ts src/pages/CategoryPage.tsx src/pages/ResultsPage.tsx src/pages/SearchPage.tsx src/components/CityFilter.tsx tailwind.config.ts` *(warnings only)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a796d2488328bc5eb55e6caa15e6