### PR TITLE
Remove roadside services from menu

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ServiceCategory } from '@/lib/api';
-import { Truck, Settings, AlertTriangle } from 'lucide-react';
+import { Settings, AlertTriangle } from 'lucide-react';
 
 interface CategorySelectorProps {
   selectedCategory?: ServiceCategory;
@@ -15,12 +15,6 @@ interface CategorySelectorProps {
 }
 
 const categories = [
-  {
-    id: 'roadside' as ServiceCategory,
-    title: 'خدمات جاده‌ای',
-    description: 'پارکینگ، سوخت، رستوران',
-    icon: Truck,
-  },
   {
     id: 'tire' as ServiceCategory,
     title: 'لاستیک و رینگ',


### PR DESCRIPTION
## Summary
- remove roadside services from category selector menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members... and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b4755b848328b920eb5146b27f0b