### PR TITLE
feat: add oil filter sales page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ContactPage } from "./pages/ContactPage";
 import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 import { TermsOfService } from "./pages/TermsOfService";
 import NotFound from "./pages/NotFound";
+import OilFilterPage from "./pages/OilFilterPage";
 
 const queryClient = new QueryClient();
 
@@ -38,6 +39,7 @@ const App = () => (
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/legal/privacy" element={<PrivacyPolicy />} />
             <Route path="/legal/terms" element={<TermsOfService />} />
+            <Route path="/oil-filter" element={<OilFilterPage />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ServiceCategory } from '@/lib/api';
-import { Truck, Settings, AlertTriangle } from 'lucide-react';
+import { Truck, Settings, AlertTriangle, Droplet } from 'lucide-react';
 
 interface CategorySelectorProps {
   selectedCategory?: ServiceCategory;
@@ -32,6 +32,12 @@ const categories = [
     title: 'امداد و حادثه',
     description: 'یدک‌کش و تعمیرات اضطراری',
     icon: AlertTriangle,
+  },
+  {
+    id: 'oil' as ServiceCategory,
+    title: 'فروش روغن و فیلتر',
+    description: 'روغن موتور و فیلترها',
+    icon: Droplet,
   },
 ];
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/data/oilFilterData.ts
+++ b/src/data/oilFilterData.ts
@@ -1,0 +1,28 @@
+export interface OilFilterInfo {
+  id: string;
+  name: string;
+  address: string;
+  phone: string;
+}
+
+export const oilFilterData: Record<string, Record<string, OilFilterInfo[]>> = {
+  'تهران': {
+    'تهران': [
+      { id: '1', name: 'فروشگاه روغن پارس', address: 'تهران، خیابان انقلاب', phone: '021-11111111' },
+      { id: '2', name: 'فروشگاه فیلتر تهران', address: 'تهران، خیابان آزادی', phone: '021-22222222' },
+    ],
+    'شمیرانات': [
+      { id: '3', name: 'روغن و فیلتر شمال', address: 'شمیرانات، خیابان دربند', phone: '021-33333333' },
+    ],
+  },
+  'اصفهان': {
+    'اصفهان': [
+      { id: '4', name: 'روغن اصفهان', address: 'اصفهان، میدان نقش جهان', phone: '031-11111111' },
+    ],
+    'کاشان': [
+      { id: '5', name: 'فروشگاه فیلتر کاشان', address: 'کاشان، خیابان ملاصدرا', phone: '031-22222222' },
+    ],
+  },
+};
+
+export default oilFilterData;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -35,7 +35,7 @@ interface ProviderSearchResult {
   categories: ServiceCategory[];
 }
 
-type ServiceCategory = 'roadside' | 'tire' | 'recovery';
+type ServiceCategory = 'roadside' | 'tire' | 'recovery' | 'oil';
 type VehicleType = 'truck' | 'semi' | 'bus';
 
 interface OtpRequest {

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -103,12 +103,18 @@ export const CategoryPage: React.FC = () => {
   };
 
   const handleCategoryChange = (newCategory: ServiceCategory) => {
+    if (newCategory === 'oil') {
+      navigate('/oil-filter');
+      return;
+    }
+
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil: 'oil-filter',
     };
-    
+
     navigate(`/c/${slugMap[newCategory]}`);
   };
 

--- a/src/pages/OilFilterPage.tsx
+++ b/src/pages/OilFilterPage.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { Header } from '@/components/Header';
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select';
+import oilFilterData, { OilFilterInfo } from '@/data/oilFilterData';
+
+const OilFilterPage: React.FC = () => {
+  const [city, setCity] = useState('');
+  const [county, setCounty] = useState('');
+
+  const cities = Object.keys(oilFilterData);
+  const counties = city ? Object.keys(oilFilterData[city]) : [];
+
+  const items: OilFilterInfo[] = city
+    ? county
+      ? oilFilterData[city][county]
+      : Object.values(oilFilterData[city]).flat()
+    : [];
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header title="فروش روغن و فیلتر" />
+      <div className="p-4 space-y-4">
+        <div>
+          <Select
+            value={city}
+            onValueChange={(value) => {
+              setCity(value);
+              setCounty('');
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="انتخاب شهر" />
+            </SelectTrigger>
+            <SelectContent>
+              {cities.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {c}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {city && (
+          <div>
+            <Select value={county} onValueChange={setCounty}>
+              <SelectTrigger>
+                <SelectValue placeholder="انتخاب شهرستان" />
+              </SelectTrigger>
+              <SelectContent>
+                {counties.map((ct) => (
+                  <SelectItem key={ct} value={ct}>
+                    {ct}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {items.map((item) => (
+            <div key={item.id} className="border rounded-lg p-4">
+              <div className="font-semibold">{item.name}</div>
+              <div className="text-sm text-muted-foreground">{item.address}</div>
+              <div className="text-sm text-muted-foreground">{item.phone}</div>
+            </div>
+          ))}
+          {city && items.length === 0 && (
+            <p className="text-center text-muted-foreground">اطلاعاتی یافت نشد</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OilFilterPage;

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -67,6 +67,11 @@ export const ResultsPage: React.FC = () => {
   };
 
   const handleCategoryChange = (newCategory: ServiceCategory) => {
+    if (newCategory === 'oil') {
+      navigate('/oil-filter');
+      return;
+    }
+
     const newParams = new URLSearchParams(searchParams);
     newParams.set('category', newCategory);
     setSearchParams(newParams);

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -13,6 +13,11 @@ export const SearchPage: React.FC = () => {
   const navigate = useNavigate();
 
   const handleDirectNavigation = (category: ServiceCategory) => {
+    if (category === 'oil') {
+      navigate('/oil-filter');
+      return;
+    }
+
     if (!lat || !lon) {
       navigate('/location-error');
       return;
@@ -21,12 +26,18 @@ export const SearchPage: React.FC = () => {
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil: 'oil-filter',
     };
     navigate(`/c/${slugMap[category]}`);
   };
 
   const handleSearch = () => {
+    if (selectedCategory === 'oil') {
+      navigate('/oil-filter');
+      return;
+    }
+
     if (!lat || !lon) {
       navigate('/location-error');
       return;
@@ -36,7 +47,8 @@ export const SearchPage: React.FC = () => {
       const slugMap: Record<ServiceCategory, string> = {
         roadside: 'roadside',
         tire: 'tyre-wheel',
-        recovery: 'recovery-accident'
+        recovery: 'recovery-accident',
+        oil: 'oil-filter',
       };
       navigate(`/c/${slugMap[selectedCategory]}`);
     } else {
@@ -102,7 +114,7 @@ export const SearchPage: React.FC = () => {
         {/* Search Button */}
         <Button
           onClick={handleSearch}
-          disabled={!hasLocation || isLoading}
+          disabled={(selectedCategory !== 'oil' && !hasLocation) || isLoading}
           className="w-full"
           size="lg"
           variant="hero"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add "فروش روغن و فیلتر" category and navigation
- include oil/filter data with city and county selection page
- update configs and lint fixes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b68c6aa88328acf0fc8d8805c4d6