### PR TITLE
Add icon for oil & filter sales menu

### DIFF
--- a/migrations/versions/0001_create_service_models.py
+++ b/migrations/versions/0001_create_service_models.py
@@ -98,6 +98,7 @@ def upgrade() -> None:
             {"slug": "roadside", "name": "roadside"},
             {"slug": "tyre-wheel", "name": "tyre-wheel"},
             {"slug": "recovery-accident", "name": "recovery-accident"},
+            {"slug": "oil-filter", "name": "oil-filter"},
         ],
     )
 

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ServiceCategory } from '@/lib/api';
-import { Truck, Settings, AlertTriangle } from 'lucide-react';
+import { Truck, Settings, AlertTriangle, Droplets } from 'lucide-react';
 
 interface CategorySelectorProps {
   selectedCategory?: ServiceCategory;
@@ -32,6 +32,12 @@ const categories = [
     title: 'امداد و حادثه',
     description: 'یدک‌کش و تعمیرات اضطراری',
     icon: AlertTriangle,
+  },
+  {
+    id: 'oil_filter' as ServiceCategory,
+    title: 'فروش روغن و فیلتر',
+    description: 'عرضه و تعویض روغن و فیلتر',
+    icon: Droplets,
   },
 ];
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -35,7 +35,7 @@ interface ProviderSearchResult {
   categories: ServiceCategory[];
 }
 
-type ServiceCategory = 'roadside' | 'tire' | 'recovery';
+type ServiceCategory = 'roadside' | 'tire' | 'recovery' | 'oil_filter';
 type VehicleType = 'truck' | 'semi' | 'bus';
 
 interface OtpRequest {
@@ -188,6 +188,19 @@ const mockProviders: Provider[] = [
     radius_km: 55,
     is_24_7: false,
     vehicle_types: ['bus']
+  }
+  ,
+  {
+    id: '11',
+    name: 'فروشگاه روغن و فیلتر ایرانیان',
+    phone: '+989177778888',
+    address: 'اتوبان تهران-قم، کیلومتر ۳۰',
+    distance_km: 9.4,
+    categories: ['oil_filter'],
+    location: { lat: 35.7019, lon: 51.3247 },
+    radius_km: 40,
+    is_24_7: false,
+    vehicle_types: ['truck', 'bus']
   }
 ];
 

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -35,6 +35,12 @@ const categoryMap: Record<string, CategoryInfo> = {
     title: 'امداد و حادثه',
     subtitle: 'یدک‌کش و امداد جاده‌ای',
     subcategories: ['یدک‌کش', 'امداد', 'جرثقیل']
+  },
+  'oil-filter': {
+    id: 'oil_filter',
+    title: 'فروش روغن و فیلتر',
+    subtitle: 'عرضه و تعویض روغن و فیلتر',
+    subcategories: ['روغن', 'فیلتر']
   }
 };
 
@@ -103,10 +109,11 @@ export const CategoryPage: React.FC = () => {
   };
 
   const handleCategoryChange = (newCategory: ServiceCategory) => {
-    const slugMap: Record<ServiceCategory, string> = {
+  const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil_filter: 'oil-filter'
     };
     
     navigate(`/c/${slugMap[newCategory]}`);

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -21,7 +21,8 @@ export const SearchPage: React.FC = () => {
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil_filter: 'oil-filter'
     };
     navigate(`/c/${slugMap[category]}`);
   };
@@ -33,11 +34,12 @@ export const SearchPage: React.FC = () => {
     }
 
     if (selectedCategory) {
-      const slugMap: Record<ServiceCategory, string> = {
-        roadside: 'roadside',
-        tire: 'tyre-wheel',
-        recovery: 'recovery-accident'
-      };
+    const slugMap: Record<ServiceCategory, string> = {
+      roadside: 'roadside',
+      tire: 'tyre-wheel',
+      recovery: 'recovery-accident',
+      oil_filter: 'oil-filter'
+    };
       navigate(`/c/${slugMap[selectedCategory]}`);
     } else {
       const params = new URLSearchParams({

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add Droplets icon to oil and filter sales category
- support oil and filter category in search and category pages
- extend service categories and seed data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0708b2883288f4c96770bf615db