### PR TITLE
Add oil filter sales page with province/city selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ContactPage } from "./pages/ContactPage";
 import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 import { TermsOfService } from "./pages/TermsOfService";
 import NotFound from "./pages/NotFound";
+import { OilFilterPage } from "./pages/OilFilterPage";
 
 const queryClient = new QueryClient();
 
@@ -38,6 +39,7 @@ const App = () => (
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/legal/privacy" element={<PrivacyPolicy />} />
             <Route path="/legal/terms" element={<TermsOfService />} />
+            <Route path="/oil-filter" element={<OilFilterPage />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -155,10 +155,7 @@ export const LocationProvider: React.FC<LocationProviderProps> = ({ children }) 
     setState(prev => ({ ...prev, error: null }));
   };
 
-  // Auto-request location on mount
-  useEffect(() => {
-    requestLocation();
-  }, []);
+  // Location is now requested explicitly by pages when needed
 
   return (
     <LocationContext.Provider

--- a/src/pages/OilFilterPage.tsx
+++ b/src/pages/OilFilterPage.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Header } from '@/components/Header';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const provinces: Record<string, string[]> = {
+  'تهران': ['تهران', 'شهریار', 'شهر قدس'],
+  'اصفهان': ['اصفهان', 'کاشان', 'نجف‌آباد'],
+  'آذربایجان شرقی': ['تبریز', 'مراغه', 'مرند'],
+};
+
+export const OilFilterPage: React.FC = () => {
+  const [province, setProvince] = useState('');
+  const [city, setCity] = useState('');
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header title="فروش روغن و فیلتر" />
+      <div className="flex-1 p-6 space-y-6">
+        <div>
+          <Label className="mb-2 block">استان</Label>
+          <Select
+            value={province}
+            onValueChange={(value) => {
+              setProvince(value);
+              setCity('');
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="انتخاب استان" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.keys(provinces).map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label className="mb-2 block">شهر</Label>
+          <Select
+            value={city}
+            onValueChange={setCity}
+            disabled={!province}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="انتخاب شهر" />
+            </SelectTrigger>
+            <SelectContent>
+              {province &&
+                provinces[province].map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OilFilterPage;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -99,6 +99,15 @@ export const SearchPage: React.FC = () => {
           />
         </div>
 
+        {/* Oil & Filter Sales Menu */}
+        <Button
+          onClick={() => navigate('/oil-filter')}
+          className="w-full"
+          variant="outline"
+        >
+          فروش روغن و فیلتر
+        </Button>
+
         {/* Search Button */}
         <Button
           onClick={handleSearch}


### PR DESCRIPTION
## Summary
- remove automatic location request
- add oil & filter sales page with province and city dropdowns
- link oil & filter page from search screen and routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c6c24c108328819f40432de5f9cf