### PR TITLE
Add province and city filters for provider search

### DIFF
--- a/src/components/LocationFilter.tsx
+++ b/src/components/LocationFilter.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo } from 'react';
+import { MapPin } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ProviderSearchResult } from '@/lib/api';
+
+interface LocationFilterProps {
+  providers: ProviderSearchResult[];
+  selectedProvince: string;
+  selectedCity: string;
+  onProvinceChange: (province: string) => void;
+  onCityChange: (city: string) => void;
+}
+
+export const LocationFilter: React.FC<LocationFilterProps> = ({
+  providers,
+  selectedProvince,
+  selectedCity,
+  onProvinceChange,
+  onCityChange,
+}) => {
+  const provinces = useMemo(
+    () => Array.from(new Set(providers.map(p => p.province))),
+    [providers]
+  );
+
+  const cities = useMemo(() => {
+    const filtered =
+      selectedProvince === 'all'
+        ? providers
+        : providers.filter(p => p.province === selectedProvince);
+    return Array.from(new Set(filtered.map(p => p.city)));
+  }, [providers, selectedProvince]);
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-2">
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <MapPin size={16} className="text-muted-foreground flex-shrink-0" />
+        <Select
+          value={selectedProvince}
+          onValueChange={value => {
+            onProvinceChange(value);
+            onCityChange('all');
+          }}
+        >
+          <SelectTrigger className="w-full min-w-[120px] h-9 text-sm">
+            <SelectValue placeholder="استان" />
+          </SelectTrigger>
+          <SelectContent className="bg-card border border-border">
+            <SelectItem value="all">تمام استان‌ها</SelectItem>
+            {provinces.map(prov => (
+              <SelectItem key={prov} value={prov}>
+                {prov}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <Select value={selectedCity} onValueChange={onCityChange}>
+          <SelectTrigger className="w-full min-w-[120px] h-9 text-sm">
+            <SelectValue placeholder="شهر" />
+          </SelectTrigger>
+          <SelectContent className="bg-card border border-border">
+            <SelectItem value="all">تمام شهرها</SelectItem>
+            {cities.map(city => (
+              <SelectItem key={city} value={city}>
+                {city}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -21,6 +21,8 @@ interface Provider {
   radius_km: number;
   is_24_7: boolean;
   vehicle_types: VehicleType[];
+  province: string;
+  city: string;
 }
 
 interface ProviderSearchResult {
@@ -33,6 +35,8 @@ interface ProviderSearchResult {
   vehicle_types: VehicleType[];
   radius_km: number;
   categories: ServiceCategory[];
+  province: string;
+  city: string;
 }
 
 type ServiceCategory = 'roadside' | 'tire' | 'recovery';
@@ -79,7 +83,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7219, lon: 51.3347 },
     radius_km: 60,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi']
+    vehicle_types: ['truck', 'semi'],
+    province: 'تهران',
+    city: 'تهران'
   },
   {
     id: '2',
@@ -91,7 +97,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7419, lon: 51.3047 },
     radius_km: 45,
     is_24_7: false,
-    vehicle_types: ['truck', 'bus']
+    vehicle_types: ['truck', 'bus'],
+    province: 'البرز',
+    city: 'کرج'
   },
   {
     id: '3',
@@ -103,7 +111,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6719, lon: 51.2747 },
     radius_km: 30,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi', 'bus']
+    vehicle_types: ['truck', 'semi', 'bus'],
+    province: 'مرکزی',
+    city: 'ساوه'
   },
   {
     id: '4',
@@ -115,7 +125,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6919, lon: 51.2647 },
     radius_km: 80,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi']
+    vehicle_types: ['truck', 'semi'],
+    province: 'تهران',
+    city: 'تهران'
   },
   {
     id: '5',
@@ -127,7 +139,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.8019, lon: 51.1547 },
     radius_km: 25,
     is_24_7: false,
-    vehicle_types: ['truck']
+    vehicle_types: ['truck'],
+    province: 'تهران',
+    city: 'شهر قدس'
   },
   {
     id: '6',
@@ -139,7 +153,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7319, lon: 51.1947 },
     radius_km: 50,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi', 'bus']
+    vehicle_types: ['truck', 'semi', 'bus'],
+    province: 'تهران',
+    city: 'تهران'
   },
   {
     id: '7',
@@ -151,7 +167,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6419, lon: 51.2347 },
     radius_km: 40,
     is_24_7: false,
-    vehicle_types: ['truck', 'semi']
+    vehicle_types: ['truck', 'semi'],
+    province: 'البرز',
+    city: 'مهرشهر'
   },
   {
     id: '8',
@@ -163,7 +181,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7519, lon: 51.2847 },
     radius_km: 35,
     is_24_7: false,
-    vehicle_types: ['truck', 'bus']
+    vehicle_types: ['truck', 'bus'],
+    province: 'تهران',
+    city: 'شهریار'
   },
   {
     id: '9',
@@ -175,7 +195,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.7819, lon: 51.3647 },
     radius_km: 20,
     is_24_7: true,
-    vehicle_types: ['truck', 'semi', 'bus']
+    vehicle_types: ['truck', 'semi', 'bus'],
+    province: 'تهران',
+    city: 'تهران'
   },
   {
     id: '10',
@@ -187,7 +209,9 @@ const mockProviders: Provider[] = [
     location: { lat: 35.6119, lon: 51.3947 },
     radius_km: 55,
     is_24_7: false,
-    vehicle_types: ['bus']
+    vehicle_types: ['bus'],
+    province: 'تهران',
+    city: 'ورامین'
   }
 ];
 
@@ -249,7 +273,9 @@ class ApiClient {
       is_24_7: p.is_24_7,
       vehicle_types: p.vehicle_types,
       radius_km: p.radius_km,
-      categories: p.categories
+      categories: p.categories,
+      province: p.province,
+      city: p.city
     }));
 
     return { success: true, data: results };

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Header } from '@/components/Header';
 import { CategorySelector } from '@/components/CategorySelector';
 import { VehicleFilter } from '@/components/VehicleFilter';
+import { LocationFilter } from '@/components/LocationFilter';
 import { ProviderCard } from '@/components/ProviderCard';
 import { Button } from '@/components/ui/button';
 import { api, ProviderSearchResult, ServiceCategory, VehicleType } from '@/lib/api';
@@ -50,6 +51,8 @@ export const CategoryPage: React.FC = () => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedVehicle, setSelectedVehicle] = useState<VehicleType | 'all'>('all');
+  const [selectedProvince, setSelectedProvince] = useState<string>('all');
+  const [selectedCity, setSelectedCity] = useState<string>('all');
 
   const categoryInfo = slug ? categoryMap[slug] : null;
 
@@ -68,8 +71,8 @@ export const CategoryPage: React.FC = () => {
   }, [lat, lon, categoryInfo]);
 
   useEffect(() => {
-    applyVehicleFilter();
-  }, [selectedVehicle, providers]);
+    applyFilters();
+  }, [selectedVehicle, selectedProvince, selectedCity, providers]);
 
   const fetchProviders = async () => {
     if (!categoryInfo) return;
@@ -90,15 +93,23 @@ export const CategoryPage: React.FC = () => {
     setIsLoading(false);
   };
 
-  const applyVehicleFilter = () => {
+  const applyFilters = () => {
     let filtered = providers;
-    
+
+    if (selectedProvince !== 'all') {
+      filtered = filtered.filter(p => p.province === selectedProvince);
+    }
+
+    if (selectedCity !== 'all') {
+      filtered = filtered.filter(p => p.city === selectedCity);
+    }
+
     if (selectedVehicle && selectedVehicle !== 'all') {
-      filtered = providers.filter(provider => 
+      filtered = filtered.filter(provider =>
         provider.vehicle_types.includes(selectedVehicle as VehicleType)
       );
     }
-    
+
     setFilteredProviders(filtered);
   };
 
@@ -167,6 +178,13 @@ export const CategoryPage: React.FC = () => {
             selectedCategory={categoryInfo.id}
             onCategorySelect={handleCategoryChange}
             variant="compact"
+          />
+          <LocationFilter
+            providers={providers}
+            selectedProvince={selectedProvince}
+            selectedCity={selectedCity}
+            onProvinceChange={setSelectedProvince}
+            onCityChange={setSelectedCity}
           />
           <div className="flex items-center gap-3">
             <div className="flex-1">

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Header } from '@/components/Header';
 import { CategorySelector } from '@/components/CategorySelector';
 import { VehicleFilter } from '@/components/VehicleFilter';
+import { LocationFilter } from '@/components/LocationFilter';
 import { ProviderCard } from '@/components/ProviderCard';
 import { Button } from '@/components/ui/button';
 import { api, ProviderSearchResult, ServiceCategory, VehicleType } from '@/lib/api';
@@ -20,6 +21,8 @@ export const ResultsPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectedProvince, setSelectedProvince] = useState<string>('all');
+  const [selectedCity, setSelectedCity] = useState<string>('all');
 
   const lat = parseFloat(searchParams.get('lat') || '0');
   const lon = parseFloat(searchParams.get('lon') || '0');
@@ -37,7 +40,7 @@ export const ResultsPage: React.FC = () => {
 
   useEffect(() => {
     applyFilters();
-  }, [vehicle, allProviders]);
+  }, [vehicle, allProviders, selectedProvince, selectedCity]);
 
   const fetchProviders = async () => {
     setIsLoading(true);
@@ -56,13 +59,21 @@ export const ResultsPage: React.FC = () => {
 
   const applyFilters = () => {
     let filtered = allProviders;
-    
+
+    if (selectedProvince !== 'all') {
+      filtered = filtered.filter(provider => provider.province === selectedProvince);
+    }
+
+    if (selectedCity !== 'all') {
+      filtered = filtered.filter(provider => provider.city === selectedCity);
+    }
+
     if (vehicle && vehicle !== 'all') {
-      filtered = allProviders.filter(provider => 
+      filtered = filtered.filter(provider =>
         provider.vehicle_types.includes(vehicle as VehicleType)
       );
     }
-    
+
     setProviders(filtered);
   };
 
@@ -128,6 +139,13 @@ export const ResultsPage: React.FC = () => {
             selectedCategory={category || undefined}
             onCategorySelect={handleCategoryChange}
             variant="compact"
+          />
+          <LocationFilter
+            providers={allProviders}
+            selectedProvince={selectedProvince}
+            selectedCity={selectedCity}
+            onProvinceChange={setSelectedProvince}
+            onCityChange={setSelectedCity}
           />
           <div className="flex items-center gap-3">
             <div className="flex-1">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add province and city fields to provider data and mock records
- introduce a reusable LocationFilter component for selecting province and city
- integrate location filter into results and category pages to narrow providers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6c995b3388328a08e77f56ef05193