### PR TITLE
feat: add oil and filter sales page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { AboutPage } from "./pages/AboutPage";
 import { ContactPage } from "./pages/ContactPage";
 import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 import { TermsOfService } from "./pages/TermsOfService";
+import { OilFilterPage } from "./pages/OilFilterPage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -38,6 +39,7 @@ const App = () => (
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/legal/privacy" element={<PrivacyPolicy />} />
             <Route path="/legal/terms" element={<TermsOfService />} />
+            <Route path="/oil-filter" element={<OilFilterPage />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;

--- a/src/pages/OilFilterPage.tsx
+++ b/src/pages/OilFilterPage.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { Header } from '@/components/Header';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+
+interface Seller {
+  id: number;
+  name: string;
+  province: string;
+  city: string;
+  address: string;
+  phone: string;
+}
+
+const sellers: Seller[] = [
+  {
+    id: 1,
+    name: 'فروشگاه روغن برتر',
+    province: 'تهران',
+    city: 'تهران',
+    address: 'خیابان آزادی',
+    phone: '+989123456789',
+  },
+  {
+    id: 2,
+    name: 'مرکز روغن اصفهان',
+    province: 'اصفهان',
+    city: 'اصفهان',
+    address: 'خیابان چهارباغ بالا',
+    phone: '+989112223334',
+  },
+  {
+    id: 3,
+    name: 'فروشگاه فیلتر تبریز',
+    province: 'آذربایجان شرقی',
+    city: 'تبریز',
+    address: 'خیابان ولیعصر',
+    phone: '+989114445556',
+  },
+];
+
+export const OilFilterPage: React.FC = () => {
+  const [selectedCity, setSelectedCity] = useState<string>();
+
+  const cities = Array.from(new Set(sellers.map((s) => s.city)));
+  const citySellers = sellers.filter((s) => s.city === selectedCity);
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header title="فروش روغن و فیلتر" />
+      <Tabs defaultValue="province" className="flex-1 p-4">
+        <TabsList className="grid grid-cols-2 mb-4">
+          <TabsTrigger value="province">استان</TabsTrigger>
+          <TabsTrigger value="city">شهر</TabsTrigger>
+        </TabsList>
+        <TabsContent value="province" className="space-y-4">
+          {sellers.map((seller) => (
+            <div
+              key={seller.id}
+              className="bg-card p-4 rounded-lg shadow-card border"
+            >
+              <h3 className="font-semibold text-mobile-base mb-1">{seller.name}</h3>
+              <p className="text-sm text-muted-foreground mb-1">
+                {seller.province} - {seller.city}
+              </p>
+              <p className="text-sm text-muted-foreground mb-2">{seller.address}</p>
+              <Button asChild variant="secondary" size="sm">
+                <a href={`tel:${seller.phone}`}>تماس</a>
+              </Button>
+            </div>
+          ))}
+        </TabsContent>
+        <TabsContent value="city" className="space-y-4">
+          <Select onValueChange={setSelectedCity}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="انتخاب شهر" />
+            </SelectTrigger>
+            <SelectContent>
+              {cities.map((city) => (
+                <SelectItem key={city} value={city}>
+                  {city}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {selectedCity ? (
+            citySellers.length > 0 ? (
+              citySellers.map((seller) => (
+                <div
+                  key={seller.id}
+                  className="bg-card p-4 rounded-lg shadow-card border"
+                >
+                  <h3 className="font-semibold text-mobile-base mb-1">{seller.name}</h3>
+                  <p className="text-sm text-muted-foreground mb-1">
+                    {seller.province} - {seller.city}
+                  </p>
+                  <p className="text-sm text-muted-foreground mb-2">{seller.address}</p>
+                  <Button asChild variant="secondary" size="sm">
+                    <a href={`tel:${seller.phone}`}>تماس</a>
+                  </Button>
+                </div>
+              ))
+            ) : (
+              <p className="text-center text-muted-foreground">
+                فروشنده‌ای یافت نشد
+              </p>
+            )
+          ) : (
+            <p className="text-center text-muted-foreground">
+              لطفاً شهر را انتخاب کنید
+            </p>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default OilFilterPage;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -111,6 +111,15 @@ export const SearchPage: React.FC = () => {
           جستجوی خدمات
         </Button>
 
+        {/* Oil and Filter Sales */}
+        <Button
+          onClick={() => navigate('/oil-filter')}
+          variant="outline"
+          className="w-full"
+        >
+          فروش روغن و فیلتر
+        </Button>
+
         {/* Provider Registration Link */}
         <div className="text-center pt-4">
           <p className="text-sm text-muted-foreground mb-2">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add page for oil and filter sellers with province and city tabs
- link from search page and configure routing
- fix lint errors in config and ui components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6cc0fd81c8328a6c608b4b60e1e1b