### PR TITLE
Add oil & filter sales section with province/city filtering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { AboutPage } from "./pages/AboutPage";
 import { ContactPage } from "./pages/ContactPage";
 import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 import { TermsOfService } from "./pages/TermsOfService";
+import { OilFilterPage } from "./pages/OilFilterPage";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -30,6 +31,7 @@ const App = () => (
             <Route path="/" element={<SearchPage />} />
             <Route path="/c/:slug" element={<CategoryPage />} />
             <Route path="/results" element={<ResultsPage />} />
+            <Route path="/oil-filter" element={<OilFilterPage />} />
             <Route path="/provider/:id" element={<ProviderDetail />} />
             <Route path="/location-error" element={<LocationError />} />
             <Route path="/signup" element={<ProviderSignup />} />

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ServiceCategory } from '@/lib/api';
-import { Truck, Settings, AlertTriangle } from 'lucide-react';
+import { Truck, Settings, AlertTriangle, Droplet } from 'lucide-react';
 
 interface CategorySelectorProps {
   selectedCategory?: ServiceCategory;
@@ -32,6 +32,12 @@ const categories = [
     title: 'امداد و حادثه',
     description: 'یدک‌کش و تعمیرات اضطراری',
     icon: AlertTriangle,
+  },
+  {
+    id: 'oil' as ServiceCategory,
+    title: 'فروش روغن و فیلتر',
+    description: 'نمایش فروشندگان روغن و فیلتر',
+    icon: Droplet,
   },
 ];
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -35,7 +35,7 @@ interface ProviderSearchResult {
   categories: ServiceCategory[];
 }
 
-type ServiceCategory = 'roadside' | 'tire' | 'recovery';
+type ServiceCategory = 'roadside' | 'tire' | 'recovery' | 'oil';
 type VehicleType = 'truck' | 'semi' | 'bus';
 
 interface OtpRequest {

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -104,12 +104,13 @@ export const CategoryPage: React.FC = () => {
 
   const handleCategoryChange = (newCategory: ServiceCategory) => {
     const slugMap: Record<ServiceCategory, string> = {
-      roadside: 'roadside',
-      tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      roadside: '/c/roadside',
+      tire: '/c/tyre-wheel',
+      recovery: '/c/recovery-accident',
+      oil: '/oil-filter'
     };
-    
-    navigate(`/c/${slugMap[newCategory]}`);
+
+    navigate(slugMap[newCategory]);
   };
 
   const handleRefreshLocation = async () => {

--- a/src/pages/OilFilterPage.tsx
+++ b/src/pages/OilFilterPage.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Header } from '@/components/Header';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+
+interface Seller {
+  id: number;
+  name: string;
+  phone: string;
+  address: string;
+  province: string;
+  city: string;
+}
+
+const sellers: Seller[] = [
+  { id: 1, name: 'فروشگاه روغن تهران', phone: '+989121234567', address: 'تهران، خیابان انقلاب', province: 'تهران', city: 'تهران' },
+  { id: 2, name: 'نمایندگی فیلتر کرج', phone: '+989126789012', address: 'کرج، خیابان اصلی', province: 'البرز', city: 'کرج' },
+  { id: 3, name: 'فروشگاه روغن اصفهان', phone: '+989131234567', address: 'اصفهان، میدان نقش جهان', province: 'اصفهان', city: 'اصفهان' }
+];
+
+export const OilFilterPage: React.FC = () => {
+  const [province, setProvince] = useState('');
+  const [city, setCity] = useState('');
+
+  const provinces = Array.from(new Set(sellers.map(s => s.province)));
+  const cities = province ? Array.from(new Set(sellers.filter(s => s.province === province).map(s => s.city))) : [];
+
+  const filtered = sellers.filter(s => {
+    if (city) return s.city === city;
+    if (province) return s.province === province;
+    return true;
+  });
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header title="فروش روغن و فیلتر" />
+      <div className="p-4 space-y-4 flex-1">
+        <Select value={province} onValueChange={(v) => { setProvince(v); setCity(''); }}>
+          <SelectTrigger>
+            <SelectValue placeholder="انتخاب استان" />
+          </SelectTrigger>
+          <SelectContent>
+            {provinces.map((p) => (
+              <SelectItem key={p} value={p}>{p}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {cities.length > 0 && (
+          <Select value={city} onValueChange={setCity}>
+            <SelectTrigger>
+              <SelectValue placeholder="انتخاب شهر" />
+            </SelectTrigger>
+            <SelectContent>
+              {cities.map((c) => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        <div className="space-y-4">
+          {filtered.map((s) => (
+            <div key={s.id} className="p-4 border rounded-lg">
+              <h3 className="font-semibold">{s.name}</h3>
+              <p className="text-sm text-muted-foreground">{s.address}</p>
+              <p className="text-sm">{s.phone}</p>
+            </div>
+          ))}
+          {filtered.length === 0 && (
+            <p className="text-center text-muted-foreground">هیچ فروشنده‌ای یافت نشد</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -67,6 +67,10 @@ export const ResultsPage: React.FC = () => {
   };
 
   const handleCategoryChange = (newCategory: ServiceCategory) => {
+    if (newCategory === 'oil') {
+      navigate('/oil-filter');
+      return;
+    }
     const newParams = new URLSearchParams(searchParams);
     newParams.set('category', newCategory);
     setSearchParams(newParams);

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -19,11 +19,12 @@ export const SearchPage: React.FC = () => {
     }
 
     const slugMap: Record<ServiceCategory, string> = {
-      roadside: 'roadside',
-      tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      roadside: '/c/roadside',
+      tire: '/c/tyre-wheel',
+      recovery: '/c/recovery-accident',
+      oil: '/oil-filter'
     };
-    navigate(`/c/${slugMap[category]}`);
+    navigate(slugMap[category]);
   };
 
   const handleSearch = () => {
@@ -34,11 +35,12 @@ export const SearchPage: React.FC = () => {
 
     if (selectedCategory) {
       const slugMap: Record<ServiceCategory, string> = {
-        roadside: 'roadside',
-        tire: 'tyre-wheel',
-        recovery: 'recovery-accident'
+        roadside: '/c/roadside',
+        tire: '/c/tyre-wheel',
+        recovery: '/c/recovery-accident',
+        oil: '/oil-filter'
       };
-      navigate(`/c/${slugMap[selectedCategory]}`);
+      navigate(slugMap[selectedCategory]);
     } else {
       const params = new URLSearchParams({
         lat: lat.toString(),

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add oil & filter sales page with province and city selectors
- expose new "فروش روغن و فیلتر" category and navigation links
- update config and utilities for new service category

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6cff2db0c83289157a5bae8672db1