### PR TITLE
Add location-based oil & filter sales browsing

### DIFF
--- a/app/utils/aliases.py
+++ b/app/utils/aliases.py
@@ -7,6 +7,8 @@ CATEGORY_ALIASES = {
     "tyre-wheel": "tyre-wheel",
     "recovery": "recovery-accident",
     "recovery-accident": "recovery-accident",
+    "oil": "oil-filter",
+    "oil-filter": "oil-filter",
 }
 
 VEHICLE_ALIASES = {
@@ -21,6 +23,7 @@ CATEGORY_CANONICAL_TO_UI = {
     "roadside": "roadside",
     "tyre-wheel": "tyre-wheel",
     "recovery-accident": "recovery",
+    "oil-filter": "oil",
 }
 
 VEHICLE_CANONICAL_TO_UI = {

--- a/migrations/versions/0002_add_oil_filter_category.py
+++ b/migrations/versions/0002_add_oil_filter_category.py
@@ -1,0 +1,30 @@
+"""add oil filter category"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    service_category_table = sa.table(
+        "service_category",
+        sa.column("slug", sa.String),
+        sa.column("name", sa.String),
+    )
+    op.bulk_insert(
+        service_category_table,
+        [
+            {"slug": "oil-filter", "name": "oil-filter"},
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DELETE FROM service_category WHERE slug='oil-filter'")
+    )

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { ServiceCategory } from '@/lib/api';
-import { Truck, Settings, AlertTriangle } from 'lucide-react';
+import { Truck, Settings, AlertTriangle, Droplet } from 'lucide-react';
 
 interface CategorySelectorProps {
   selectedCategory?: ServiceCategory;
@@ -32,6 +32,12 @@ const categories = [
     title: 'امداد و حادثه',
     description: 'یدک‌کش و تعمیرات اضطراری',
     icon: AlertTriangle,
+  },
+  {
+    id: 'oil' as ServiceCategory,
+    title: 'فروش روغن و فیلتر',
+    description: 'نمایندگی‌ها و فروشگاه‌های روغن',
+    icon: Droplet,
   },
 ];
 

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { MapPin } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+interface LocationOption {
+  name: string;
+  lat: number;
+  lon: number;
+}
+
+interface LocationSelectorProps {
+  locations: LocationOption[];
+  value?: string;
+  onSelect: (location: LocationOption) => void;
+}
+
+export const LocationSelector: React.FC<LocationSelectorProps> = ({ locations, value, onSelect }) => {
+  const handleChange = (val: string) => {
+    const loc = locations.find(l => l.name === val);
+    if (loc) onSelect(loc);
+  };
+
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <MapPin size={16} className="text-muted-foreground flex-shrink-0" />
+      <Select value={value} onValueChange={handleChange}>
+        <SelectTrigger className="w-full min-w-[120px] h-9 text-sm">
+          <SelectValue placeholder="استان یا شهر" />
+        </SelectTrigger>
+        <SelectContent className="bg-card border border-border max-h-[200px] overflow-y-auto">
+          {locations.map(loc => (
+            <SelectItem key={loc.name} value={loc.name} className="hover:bg-accent">
+              {loc.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -35,7 +35,7 @@ interface ProviderSearchResult {
   categories: ServiceCategory[];
 }
 
-type ServiceCategory = 'roadside' | 'tire' | 'recovery';
+type ServiceCategory = 'roadside' | 'tire' | 'recovery' | 'oil';
 type VehicleType = 'truck' | 'semi' | 'bus';
 
 interface OtpRequest {
@@ -188,6 +188,30 @@ const mockProviders: Provider[] = [
     radius_km: 55,
     is_24_7: false,
     vehicle_types: ['bus']
+  },
+  {
+    id: '11',
+    name: 'روغن فروشی تهران',
+    phone: '+989177788899',
+    address: 'تهران، خیابان انقلاب',
+    distance_km: 4.2,
+    categories: ['oil'],
+    location: { lat: 35.6892, lon: 51.3890 },
+    radius_km: 30,
+    is_24_7: false,
+    vehicle_types: ['truck', 'semi']
+  },
+  {
+    id: '12',
+    name: 'فروشگاه فیلتر اصفهان',
+    phone: '+989188899900',
+    address: 'اصفهان، میدان نقش جهان',
+    distance_km: 3.5,
+    categories: ['oil'],
+    location: { lat: 32.6539, lon: 51.6660 },
+    radius_km: 25,
+    is_24_7: true,
+    vehicle_types: ['truck']
   }
 ];
 
@@ -231,21 +255,42 @@ class ApiClient {
     await new Promise(resolve => setTimeout(resolve, 500)); // Simulate network delay
     
     let filteredProviders = mockProviders;
-    
+
     if (category) {
       filteredProviders = filteredProviders.filter(p => p.categories.includes(category));
     }
-    
+
     if (vehicle) {
       filteredProviders = filteredProviders.filter(p => p.vehicle_types.includes(vehicle));
     }
+
+    const toRad = (value: number) => (value * Math.PI) / 180;
+    const calcDistance = (lat1: number, lon1: number, lat2: number, lon2: number) => {
+      const R = 6371; // km
+      const dLat = toRad(lat2 - lat1);
+      const dLon = toRad(lon2 - lon1);
+      const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      return R * c;
+    };
+
+    filteredProviders = filteredProviders
+      .map(p => ({
+        ...p,
+        distance_km: calcDistance(lat, lon, p.location.lat, p.location.lon)
+      }))
+      .filter(p => p.distance_km <= p.radius_km)
+      .sort((a, b) => a.distance_km - b.distance_km);
 
     const results: ProviderSearchResult[] = filteredProviders.map(p => ({
       id: p.id,
       name: p.name,
       phone: p.phone,
       address: p.address,
-      distance_km: p.distance_km,
+      distance_km: Math.round(p.distance_km * 10) / 10,
       is_24_7: p.is_24_7,
       vehicle_types: p.vehicle_types,
       radius_km: p.radius_km,

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Header } from '@/components/Header';
 import { CategorySelector } from '@/components/CategorySelector';
 import { VehicleFilter } from '@/components/VehicleFilter';
+import { LocationSelector } from '@/components/LocationSelector';
 import { ProviderCard } from '@/components/ProviderCard';
 import { Button } from '@/components/ui/button';
 import { api, ProviderSearchResult, ServiceCategory, VehicleType } from '@/lib/api';
@@ -35,8 +36,20 @@ const categoryMap: Record<string, CategoryInfo> = {
     title: 'امداد و حادثه',
     subtitle: 'یدک‌کش و امداد جاده‌ای',
     subcategories: ['یدک‌کش', 'امداد', 'جرثقیل']
+  },
+  'oil-filter': {
+    id: 'oil',
+    title: 'فروش روغن و فیلتر',
+    subtitle: 'نمایندگی‌ها و فروشگاه‌های روغن',
+    subcategories: ['روغن', 'فیلتر', 'لوازم یدکی']
   }
 };
+
+const locations = [
+  { name: 'تهران', lat: 35.6892, lon: 51.3890 },
+  { name: 'اصفهان', lat: 32.6539, lon: 51.6660 },
+  { name: 'مشهد', lat: 36.2605, lon: 59.6168 }
+];
 
 export const CategoryPage: React.FC = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -50,22 +63,31 @@ export const CategoryPage: React.FC = () => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedVehicle, setSelectedVehicle] = useState<VehicleType | 'all'>('all');
+  const [manualLocation, setManualLocation] = useState<{lat: number; lon: number} | null>(null);
+  const [selectedLocationName, setSelectedLocationName] = useState<string | undefined>();
 
   const categoryInfo = slug ? categoryMap[slug] : null;
 
   useEffect(() => {
-    if (!lat || !lon) {
-      navigate('/location-error');
-      return;
-    }
-
     if (!categoryInfo) {
       navigate('/');
       return;
     }
 
+    if (categoryInfo.id === 'oil') {
+      if (!manualLocation) {
+        setIsLoading(false);
+        return;
+      }
+    } else {
+      if (!lat || !lon) {
+        navigate('/location-error');
+        return;
+      }
+    }
+
     fetchProviders();
-  }, [lat, lon, categoryInfo]);
+  }, [lat, lon, categoryInfo, manualLocation]);
 
   useEffect(() => {
     applyVehicleFilter();
@@ -73,11 +95,18 @@ export const CategoryPage: React.FC = () => {
 
   const fetchProviders = async () => {
     if (!categoryInfo) return;
-    
+
     setIsLoading(true);
     setError(null);
 
-    const response = await api.searchProviders(lat!, lon!, categoryInfo.id);
+    const searchLat = categoryInfo.id === 'oil' ? manualLocation?.lat : lat!;
+    const searchLon = categoryInfo.id === 'oil' ? manualLocation?.lon : lon!;
+    if (searchLat == null || searchLon == null) {
+      setIsLoading(false);
+      return;
+    }
+
+    const response = await api.searchProviders(searchLat, searchLon, categoryInfo.id);
     
     if (response.success && response.data) {
       // Sort by distance
@@ -106,7 +135,8 @@ export const CategoryPage: React.FC = () => {
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil: 'oil-filter'
     };
     
     navigate(`/c/${slugMap[newCategory]}`);
@@ -175,23 +205,38 @@ export const CategoryPage: React.FC = () => {
                 onValueChange={setSelectedVehicle}
               />
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleRefreshLocation}
-              disabled={isRefreshing}
-              className="flex items-center gap-2 flex-shrink-0"
-            >
-              <RefreshCw size={16} className={isRefreshing ? 'animate-spin' : ''} />
-              {isRefreshing ? 'در حال به‌روزرسانی...' : 'به‌روزرسانی موقعیت'}
-            </Button>
+            {categoryInfo.id === 'oil' ? (
+              <LocationSelector
+                locations={locations}
+                value={selectedLocationName}
+                onSelect={(loc) => {
+                  setSelectedLocationName(loc.name);
+                  setManualLocation({ lat: loc.lat, lon: loc.lon });
+                }}
+              />
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRefreshLocation}
+                disabled={isRefreshing}
+                className="flex items-center gap-2 flex-shrink-0"
+              >
+                <RefreshCw size={16} className={isRefreshing ? 'animate-spin' : ''} />
+                {isRefreshing ? 'در حال به‌روزرسانی...' : 'به‌روزرسانی موقعیت'}
+              </Button>
+            )}
           </div>
         </div>
       </div>
 
       {/* Results */}
       <div className="flex-1 p-4">
-        {error ? (
+        {categoryInfo.id === 'oil' && !manualLocation ? (
+          <div className="text-center py-8">
+            <p className="text-muted-foreground">لطفاً استان یا شهر را انتخاب کنید</p>
+          </div>
+        ) : error ? (
           <div className="text-center py-8">
             <p className="text-destructive mb-4">{error}</p>
             <Button onClick={fetchProviders} variant="outline">
@@ -203,13 +248,13 @@ export const CategoryPage: React.FC = () => {
             <MapPin size={48} className="mx-auto mb-4 text-muted-foreground" />
             <h3 className="text-lg font-semibold mb-2">هیچ خدماتی یافت نشد</h3>
             <p className="text-muted-foreground mb-4">
-              {selectedVehicle && selectedVehicle !== 'all' 
+              {selectedVehicle && selectedVehicle !== 'all'
                 ? `نتیجه‌ای برای این دسته با فیلتر ${selectedVehicle === 'truck' ? 'کامیون' : selectedVehicle === 'semi' ? 'تریلی' : 'اتوبوس'} پیدا نشد.`
                 : 'در این منطقه ارائه‌دهنده‌ای برای این نوع خدمات یافت نشد'
               }
             </p>
-            <Button 
-              onClick={() => navigate('/')} 
+            <Button
+              onClick={() => navigate('/')}
               variant="outline"
             >
               جستجوی جدید
@@ -225,7 +270,7 @@ export const CategoryPage: React.FC = () => {
                 </span>
               )}
             </div>
-            
+
             {filteredProviders.map((provider) => (
               <ProviderCard key={provider.id} provider={provider} />
             ))}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -13,7 +13,7 @@ export const SearchPage: React.FC = () => {
   const navigate = useNavigate();
 
   const handleDirectNavigation = (category: ServiceCategory) => {
-    if (!lat || !lon) {
+    if (category !== 'oil' && (!lat || !lon)) {
       navigate('/location-error');
       return;
     }
@@ -21,13 +21,14 @@ export const SearchPage: React.FC = () => {
     const slugMap: Record<ServiceCategory, string> = {
       roadside: 'roadside',
       tire: 'tyre-wheel',
-      recovery: 'recovery-accident'
+      recovery: 'recovery-accident',
+      oil: 'oil-filter'
     };
     navigate(`/c/${slugMap[category]}`);
   };
 
   const handleSearch = () => {
-    if (!lat || !lon) {
+    if ((!lat || !lon) && selectedCategory !== 'oil') {
       navigate('/location-error');
       return;
     }
@@ -36,7 +37,8 @@ export const SearchPage: React.FC = () => {
       const slugMap: Record<ServiceCategory, string> = {
         roadside: 'roadside',
         tire: 'tyre-wheel',
-        recovery: 'recovery-accident'
+        recovery: 'recovery-accident',
+        oil: 'oil-filter'
       };
       navigate(`/c/${slugMap[selectedCategory]}`);
     } else {
@@ -102,7 +104,7 @@ export const SearchPage: React.FC = () => {
         {/* Search Button */}
         <Button
           onClick={handleSearch}
-          disabled={!hasLocation || isLoading}
+          disabled={(selectedCategory !== 'oil' && !hasLocation) || isLoading}
           className="w-full"
           size="lg"
           variant="hero"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- support oil and filter sales category with mock providers
- allow selecting province or city to load oil & filter vendors
- document new oil-filter service category and migration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6d3817838832884ee00d4ed2483bc