### PR TITLE
feat: add home menu and services routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { LocationProvider } from "@/contexts/LocationContext";
+import Index from "./pages/Index";
 import { SearchPage } from "./pages/SearchPage";
 import { CategoryPage } from "./pages/CategoryPage";
 import { ResultsPage } from "./pages/ResultsPage";
@@ -27,7 +28,8 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<SearchPage />} />
+            <Route path="/" element={<Index />} />
+            <Route path="/services" element={<SearchPage />} />
             <Route path="/c/:slug" element={<CategoryPage />} />
             <Route path="/results" element={<ResultsPage />} />
             <Route path="/provider/:id" element={<ProviderDetail />} />

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -70,7 +70,7 @@ export const CategoryPage: React.FC = () => {
 
   useEffect(() => {
     if (!categoryInfo) {
-      navigate('/');
+      navigate('/services');
       return;
     }
 
@@ -254,7 +254,7 @@ export const CategoryPage: React.FC = () => {
               }
             </p>
             <Button
-              onClick={() => navigate('/')}
+              onClick={() => navigate('/services')}
               variant="outline"
             >
               جستجوی جدید

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,25 @@
-// Update this page (the content is just a fallback if you fail to update the page)
+import { Link } from 'react-router-dom';
 
 const Index = () => {
+  const menuItems = [
+    { title: 'خانه', path: '/' },
+    { title: 'خدمات', path: '/services' },
+    { title: 'درباره', path: '/about' },
+    { title: 'تماس با ما', path: '/contact' },
+  ];
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">Welcome to Your Blank App</h1>
-        <p className="text-xl text-muted-foreground">Start building your amazing project here!</p>
+      <div className="grid grid-cols-2 gap-4 w-full max-w-md p-4">
+        {menuItems.map((item) => (
+          <Link
+            key={item.title}
+            to={item.path}
+            className="bg-card rounded-lg shadow-card flex items-center justify-center p-6 text-lg font-medium hover:bg-accent transition-colors"
+          >
+            {item.title}
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/src/pages/LocationError.tsx
+++ b/src/pages/LocationError.tsx
@@ -40,7 +40,7 @@ export const LocationError: React.FC = () => {
     await new Promise(resolve => setTimeout(resolve, 500));
     
     setIsSubmitting(false);
-    navigate('/');
+    navigate('/services');
   };
 
   return (

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -169,8 +169,8 @@ export const ResultsPage: React.FC = () => {
                 : 'در این منطقه ارائه‌دهنده‌ای برای این نوع خدمات یافت نشد'
               }
             </p>
-            <Button 
-              onClick={() => navigate('/')} 
+            <Button
+              onClick={() => navigate('/services')}
               variant="outline"
             >
               جستجوی جدید

--- a/src/pages/SignupSuccess.tsx
+++ b/src/pages/SignupSuccess.tsx
@@ -69,8 +69,8 @@ export const SignupSuccess: React.FC = () => {
 
           {/* Action Buttons */}
           <div className="space-y-3">
-            <Button 
-              onClick={() => navigate('/')}
+            <Button
+              onClick={() => navigate('/services')}
               className="w-full"
               size="lg"
               variant="hero"


### PR DESCRIPTION
## Summary
- create 2x2 home page menu linking to home, services, about, contact
- route '/' to new home page and move search to '/services'
- update internal navigation to point to services path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 15 problems, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ef07e788328b900a44bb560fb81