### PR TITLE
Add maintenance-themed background to landing page

### DIFF
--- a/public/maintenance-bg.svg
+++ b/public/maintenance-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <pattern id="stripes" patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="rotate(45)">
+      <rect width="5" height="10" fill="#f59e0b" />
+      <rect x="5" width="5" height="10" fill="#1e293b" />
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#stripes)" />
+</svg>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,10 +2,15 @@
 
 const Index = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">Welcome to Your Blank App</h1>
-        <p className="text-xl text-muted-foreground">Start building your amazing project here!</p>
+    <div
+      className="min-h-screen flex items-center justify-center bg-center bg-repeat"
+      style={{ backgroundImage: "url('/maintenance-bg.svg')" }}
+    >
+      <div className="bg-black/60 p-8 rounded text-center">
+        <h1 className="text-4xl font-bold mb-4 text-white">Truck Maintenance Finder</h1>
+        <p className="text-xl text-gray-200">
+          Locate service providers for heavy vehicles.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- create hazard-stripe SVG background asset
- apply background and updated copy to home page

## Testing
- `npm run lint` *(fails: Unexpected any, no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b853537e5c832895b4f1f151dfd1d5