### PR TITLE
feat: add truck-themed background

### DIFF
--- a/public/truck-bg.svg
+++ b/public/truck-bg.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 1024">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="1024" fill="url(#bg)" />
+  <g fill="none" stroke="#cbd5e1" stroke-width="8" opacity="0.4" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M200 700h500l80 120h360v-160h-60l-120-200H200z" />
+    <circle cx="420" cy="820" r="60" />
+    <circle cx="740" cy="820" r="60" />
+  </g>
+</svg>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,7 +9,9 @@ const Index = () => {
   ];
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <div
+      className="min-h-screen flex items-center justify-center bg-background bg-[url('/truck-bg.svg')] bg-cover bg-center bg-no-repeat"
+    >
       <div className="grid grid-cols-2 gap-4 w-full max-w-md p-4">
         {menuItems.map((item) => (
           <Link


### PR DESCRIPTION
## Summary
- add truck silhouette background asset
- apply background image to home menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 2 errors, 13 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b85e34e6dc8328b4dd594bad81395d