### PR TITLE
feat: update home background and trim

### DIFF
--- a/public/truck-bg.svg
+++ b/public/truck-bg.svg
@@ -4,11 +4,13 @@
       <stop offset="0%" stop-color="#f1f5f9" />
       <stop offset="100%" stop-color="#e2e8f0" />
     </linearGradient>
+    <pattern id="tools" width="120" height="120" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <path d="M20 20l40 40m0-40l-40 40" stroke="#cbd5e1" stroke-width="8" stroke-linecap="round" />
+      <path d="M80 20l40 40m0-40l-40 40" stroke="#cbd5e1" stroke-width="8" stroke-linecap="round" />
+      <path d="M20 80l40 40m0-40l-40 40" stroke="#cbd5e1" stroke-width="8" stroke-linecap="round" />
+      <path d="M80 80l40 40m0-40l-40 40" stroke="#cbd5e1" stroke-width="8" stroke-linecap="round" />
+    </pattern>
   </defs>
   <rect width="1440" height="1024" fill="url(#bg)" />
-  <g fill="none" stroke="#cbd5e1" stroke-width="8" opacity="0.4" stroke-linejoin="round" stroke-linecap="round">
-    <path d="M200 700h500l80 120h360v-160h-60l-120-200H200z" />
-    <circle cx="420" cy="820" r="60" />
-    <circle cx="740" cy="820" r="60" />
-  </g>
+  <rect width="1440" height="1024" fill="url(#tools)" opacity="0.3" />
 </svg>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,19 +9,19 @@ const Index = () => {
   ];
 
   return (
-    <div
-      className="min-h-screen flex items-center justify-center bg-background bg-[url('/truck-bg.svg')] bg-cover bg-center bg-no-repeat"
-    >
-      <div className="grid grid-cols-2 gap-4 w-full max-w-md p-4">
-        {menuItems.map((item) => (
-          <Link
-            key={item.title}
-            to={item.path}
-            className="bg-card rounded-lg shadow-card flex items-center justify-center p-6 text-lg font-medium hover:bg-accent transition-colors"
-          >
-            {item.title}
-          </Link>
-        ))}
+    <div className="min-h-screen flex items-center justify-center bg-background bg-[url('/truck-bg.svg')] bg-cover bg-center bg-no-repeat">
+      <div className="p-1 rounded-xl gradient-hero shadow-card">
+        <div className="grid grid-cols-2 gap-4 w-full max-w-md p-4 bg-card rounded-lg">
+          {menuItems.map((item) => (
+            <Link
+              key={item.title}
+              to={item.path}
+              className="bg-card rounded-lg shadow-card flex items-center justify-center p-6 text-lg font-medium hover:bg-accent transition-colors"
+            >
+              {item.title}
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace truck silhouette background with repeating tool pattern for more practical look
- accent home menu with gradient border using existing hero colors

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Fast refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b86022fee0832887b41f7ffa9f5dc2