### PR TITLE
refactor: remove redundant location card

### DIFF
--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -5,11 +5,11 @@ import { CategorySelector } from '@/components/CategorySelector';
 import { Footer } from '@/components/Footer';
 import { useLocation } from '@/contexts/LocationContext';
 import { ServiceCategory } from '@/lib/api';
-import { MapPin, Search, Truck } from 'lucide-react';
+import { Search, Truck } from 'lucide-react';
 
 export const SearchPage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<ServiceCategory | undefined>();
-  const { lat, lon, isLoading, error, requestLocation } = useLocation();
+  const { lat, lon, isLoading } = useLocation();
   const navigate = useNavigate();
 
   const handleDirectNavigation = (category: ServiceCategory) => {
@@ -65,31 +65,6 @@ export const SearchPage: React.FC = () => {
 
       {/* Main Content */}
       <div className="flex-1 p-6 space-y-6">
-        {/* Location Status */}
-        <div className="bg-card p-4 rounded-lg shadow-card">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <MapPin size={20} className="text-primary" />
-              <span className="text-mobile-base">
-                {isLoading ? 'در حال یافتن موقعیت...' : 
-                 hasLocation ? 'موقعیت شما تأیید شد' : 
-                 'موقعیت مورد نیاز'}
-              </span>
-            </div>
-            {!hasLocation && !isLoading && (
-              <Button variant="outline" size="sm" onClick={requestLocation}>
-                تأیید موقعیت
-              </Button>
-            )}
-          </div>
-          
-          {error && (
-            <div className="mt-2 text-sm text-destructive">
-              {error}
-            </div>
-          )}
-        </div>
-
         {/* Category Selection */}
         <div>
           <h2 className="text-mobile-lg font-semibold mb-4">نوع خدمات مورد نیاز</h2>


### PR DESCRIPTION
## Summary
- drop location status card from search page

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b864d0c81c8328ae0c1f3751849643