### PR TITLE
Enforce service selection before provider signup submission

### DIFF
--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -281,6 +281,9 @@ export const ProviderSignup: React.FC = () => {
                     multiSelect={true}
                     selectedCategories={selectedCategories}
                   />
+                  <p className="text-sm text-muted-foreground mt-2">
+                    حداقل یک دسته خدمات انتخاب کنید
+                  </p>
                 </CardContent>
               </Card>
 


### PR DESCRIPTION
## Summary
- Clarify service selection requirement on provider signup form with helper text
- Keep submission disabled until at least one service is chosen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b869fafb8c832886e055e152c63401