### PR TITLE
feat: save company information on signup

### DIFF
--- a/app/api/providers.py
+++ b/app/api/providers.py
@@ -7,7 +7,7 @@ from geoalchemy2 import WKTElement
 
 from ..config import JWT_SECRET
 from ..db import get_db
-from ..models import Provider, ServiceCategory, VehicleType
+from ..models import Company, Provider, ServiceCategory, VehicleType
 from ..utils.aliases import (
     normalize_category,
     normalize_vehicle,
@@ -87,6 +87,11 @@ def register_provider():
     ).scalars().all()
     if len(vehicles_db) != len(set(veh_slugs)):
         return json_error("unknown_vehicle_type", "unknown vehicle type")
+
+    company = db.execute(select(Company).where(Company.tel == phone)).scalar_one_or_none()
+    if not company:
+        company = Company(name=name, tel=phone)
+        db.add(company)
 
     point = WKTElement(f"POINT({lon} {lat})", srid=4326)
     provider = Provider(

--- a/app/models.py
+++ b/app/models.py
@@ -32,6 +32,14 @@ class VehicleType(Base):
     name = Column(String(100), nullable=False)
 
 
+class Company(Base):
+    __tablename__ = "company"
+
+    id = Column(Integer, primary_key=True)
+    tel = Column(String(20), unique=True, nullable=False)
+    name = Column(String(255), nullable=False)
+
+
 provider_category = Table(
     "provider_category",
     Base.metadata,

--- a/migrations/versions/0003_create_company_table.py
+++ b/migrations/versions/0003_create_company_table.py
@@ -1,0 +1,23 @@
+"""create company table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "company",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tel", sa.String(length=20), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("company")


### PR DESCRIPTION
## Summary
- add Company model and migration for phone and name
- persist company info when registering a provider

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b88ea54c908328bbb13f478ac7d031