### PR TITLE
feat: save company info after phone verification

### DIFF
--- a/app/api/providers.py
+++ b/app/api/providers.py
@@ -34,6 +34,32 @@ def _auth_phone():
     return payload.get("phone")
 
 
+@bp.post("/company")
+def register_company():
+    """Store company information using a verified phone JWT."""
+    token_phone = _auth_phone()
+    if not token_phone:
+        return json_error("unauthorized", "invalid or missing token", 401)
+
+    data = request.get_json() or {}
+    name = data.get("name")
+    phone = data.get("phone")
+    if not all([name, phone]):
+        return json_error("invalid_request", "missing fields")
+    if phone != token_phone:
+        return json_error("phone_mismatch", "phone mismatch", 401)
+
+    db = get_db()
+    company = db.execute(select(Company).where(Company.tel == phone)).scalar_one_or_none()
+    if company:
+        company.name = name
+    else:
+        company = Company(name=name, tel=phone)
+        db.add(company)
+    db.commit()
+    return {"id": company.id}
+
+
 @bp.post("/")
 def register_provider():
     """Register a new provider using a verified phone JWT."""

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -56,6 +56,11 @@ interface ProviderRegistration {
   vehicle_types: VehicleType[];
 }
 
+interface CompanyRegistration {
+  name: string;
+  phone: string;
+}
+
 interface ContactForm {
   name: string;
   email: string;
@@ -319,13 +324,23 @@ class ApiClient {
   // Verify OTP code
   async verifyOtp(phone: string, code: string): Promise<ApiResponse<{ token: string }>> {
     await new Promise(resolve => setTimeout(resolve, 600));
-    
+
     // Mock verification - accept any 6-digit code
     if (code.length === 6) {
       return { success: true, data: { token: 'mock-jwt-token' } };
     }
 
     return { success: false, error: 'کد تأیید نامعتبر است' };
+  }
+
+  // Register company information
+  async registerCompany(
+    data: CompanyRegistration,
+    token: string
+  ): Promise<ApiResponse<{ id: string }>> {
+    await new Promise(resolve => setTimeout(resolve, 600));
+
+    return { success: true, data: { id: '1' } };
   }
 
   // Register new provider
@@ -358,9 +373,20 @@ export const requestOTP = (phone: string) => api.requestOtp(phone);
 
 export const verifyOTP = (phone: string, code: string) => api.verifyOtp(phone, code);
 
-export const createProvider = (data: ProviderRegistration, token?: string) => 
+export const createCompany = (data: CompanyRegistration, token?: string) =>
+  api.registerCompany(data, token || 'mock-token');
+
+export const createProvider = (data: ProviderRegistration, token?: string) =>
   api.registerProvider(data, token || 'mock-token');
 
 export const submitContactForm = (data: ContactForm) => api.submitContact(data);
 
-export type { Provider, ProviderSearchResult, ServiceCategory, VehicleType, ProviderRegistration, ContactForm };
+export type {
+  Provider,
+  ProviderSearchResult,
+  ServiceCategory,
+  VehicleType,
+  ProviderRegistration,
+  CompanyRegistration,
+  ContactForm,
+};

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { CategorySelector } from '@/components/CategorySelector';
 import { Header } from '@/components/Header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider } from '@/lib/api';
+import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider, createCompany } from '@/lib/api';
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
@@ -98,7 +98,7 @@ export const ProviderSignup: React.FC = () => {
     }
   };
 
-  const handleCompanySubmit = () => {
+  const handleCompanySubmit = async () => {
     if (!companyName.trim()) {
       toast({
         title: "خطا",
@@ -107,7 +107,20 @@ export const ProviderSignup: React.FC = () => {
       });
       return;
     }
-    setCurrentStep('details');
+
+    setIsLoading(true);
+    try {
+      await createCompany({ name: companyName, phone });
+      setCurrentStep('details');
+    } catch (error) {
+      toast({
+        title: "خطا در ثبت شرکت",
+        description: "لطفاً دوباره تلاش کنید",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleSubmit = async () => {


### PR DESCRIPTION
## Summary
- add POST /company endpoint to save company name and phone
- expose createCompany API and call it during signup flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89daff210832890ad76c84c59214f