### PR TITLE
Remove search button from services page

### DIFF
--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -5,11 +5,11 @@ import { CategorySelector } from '@/components/CategorySelector';
 import { Footer } from '@/components/Footer';
 import { useLocation } from '@/contexts/LocationContext';
 import { ServiceCategory } from '@/lib/api';
-import { Search, Truck } from 'lucide-react';
+import { Truck } from 'lucide-react';
 
 export const SearchPage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<ServiceCategory | undefined>();
-  const { lat, lon, isLoading } = useLocation();
+  const { lat, lon } = useLocation();
   const navigate = useNavigate();
 
   const handleDirectNavigation = (category: ServiceCategory) => {
@@ -26,31 +26,6 @@ export const SearchPage: React.FC = () => {
     };
     navigate(`/c/${slugMap[category]}`);
   };
-
-  const handleSearch = () => {
-    if ((!lat || !lon) && selectedCategory !== 'oil') {
-      navigate('/location-error');
-      return;
-    }
-
-    if (selectedCategory) {
-      const slugMap: Record<ServiceCategory, string> = {
-        roadside: 'roadside',
-        tire: 'tyre-wheel',
-        recovery: 'recovery-accident',
-        oil: 'oil-filter'
-      };
-      navigate(`/c/${slugMap[selectedCategory]}`);
-    } else {
-      const params = new URLSearchParams({
-        lat: lat.toString(),
-        lon: lon.toString(),
-      });
-      navigate(`/results?${params.toString()}`);
-    }
-  };
-
-  const hasLocation = lat && lon;
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -75,18 +50,6 @@ export const SearchPage: React.FC = () => {
             onDirectNavigate={handleDirectNavigation}
           />
         </div>
-
-        {/* Search Button */}
-        <Button
-          onClick={handleSearch}
-          disabled={(selectedCategory !== 'oil' && !hasLocation) || isLoading}
-          className="w-full"
-          size="lg"
-          variant="hero"
-        >
-          <Search className="ml-2" size={20} />
-          جستجوی خدمات
-        </Button>
 
         {/* Provider Registration Link */}
         <div className="text-center pt-4">


### PR DESCRIPTION
## Summary
- Remove service search button from services page to streamline navigation
- Simplify SearchPage by dropping unused location logic and search handler

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b93106a0988328b6afa0cabde7320e