### PR TITLE
feat: persist company data to API

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -314,23 +314,19 @@ class ApiClient {
   }
 
   // Request OTP for phone verification
-  async requestOtp(phone: string): Promise<ApiResponse<{ success: boolean }>> {
-    await new Promise(resolve => setTimeout(resolve, 800));
-    
-    // Mock success response
-    return { success: true, data: { success: true } };
+  async requestOtp(phone: string): Promise<ApiResponse<{ code?: string }>> {
+    return this.request('/auth/request-otp', {
+      method: 'POST',
+      body: JSON.stringify({ phone })
+    });
   }
 
   // Verify OTP code
   async verifyOtp(phone: string, code: string): Promise<ApiResponse<{ token: string }>> {
-    await new Promise(resolve => setTimeout(resolve, 600));
-
-    // Mock verification - accept any 6-digit code
-    if (code.length === 6) {
-      return { success: true, data: { token: 'mock-jwt-token' } };
-    }
-
-    return { success: false, error: 'کد تأیید نامعتبر است' };
+    return this.request('/auth/verify-otp', {
+      method: 'POST',
+      body: JSON.stringify({ phone, code })
+    });
   }
 
   // Register company information
@@ -338,9 +334,13 @@ class ApiClient {
     data: CompanyRegistration,
     token: string
   ): Promise<ApiResponse<{ id: string }>> {
-    await new Promise(resolve => setTimeout(resolve, 600));
-
-    return { success: true, data: { id: '1' } };
+    return this.request('/providers/company', {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
   }
 
   // Register new provider
@@ -348,9 +348,13 @@ class ApiClient {
     data: ProviderRegistration,
     token: string
   ): Promise<ApiResponse<{ status: string }>> {
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    return { success: true, data: { status: 'pending' } };
+    return this.request('/providers', {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
   }
 
   // Submit contact form
@@ -373,11 +377,11 @@ export const requestOTP = (phone: string) => api.requestOtp(phone);
 
 export const verifyOTP = (phone: string, code: string) => api.verifyOtp(phone, code);
 
-export const createCompany = (data: CompanyRegistration, token?: string) =>
-  api.registerCompany(data, token || 'mock-token');
+export const createCompany = (data: CompanyRegistration, token: string) =>
+  api.registerCompany(data, token);
 
-export const createProvider = (data: ProviderRegistration, token?: string) =>
-  api.registerProvider(data, token || 'mock-token');
+export const createProvider = (data: ProviderRegistration, token: string) =>
+  api.registerProvider(data, token);
 
 export const submitContactForm = (data: ContactForm) => api.submitContact(data);
 

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -25,6 +25,7 @@ export const ProviderSignup: React.FC = () => {
   const [phone, setPhone] = useState('');
   const [otp, setOtp] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [authToken, setAuthToken] = useState<string | null>(null);
   
   // Business details
   const [companyName, setCompanyName] = useState('');
@@ -52,12 +53,16 @@ export const ProviderSignup: React.FC = () => {
 
     setIsLoading(true);
     try {
-      await requestOTP(phone);
-      setCurrentStep('otp');
-      toast({
-        title: "کد تأیید ارسال شد",
-        description: "کد ۶ رقمی به شماره شما پیامک شد",
-      });
+      const res = await requestOTP(phone);
+      if (res.success) {
+        setCurrentStep('otp');
+        toast({
+          title: "کد تأیید ارسال شد",
+          description: "کد ۶ رقمی به شماره شما پیامک شد",
+        });
+      } else {
+        throw new Error(res.error || '');
+      }
     } catch (error) {
       toast({
         title: "خطا در ارسال کد",
@@ -81,12 +86,17 @@ export const ProviderSignup: React.FC = () => {
 
     setIsLoading(true);
     try {
-      await verifyOTP(phone, otp);
-      setCurrentStep('company');
-      toast({
-        title: "شماره تأیید شد",
-        description: "نام شرکت خود را وارد کنید",
-      });
+      const res = await verifyOTP(phone, otp);
+      if (res.success && res.data) {
+        setAuthToken(res.data.token);
+        setCurrentStep('company');
+        toast({
+          title: "شماره تأیید شد",
+          description: "نام شرکت خود را وارد کنید",
+        });
+      } else {
+        throw new Error(res.error || '');
+      }
     } catch (error) {
       toast({
         title: "کد نامعتبر",
@@ -110,8 +120,12 @@ export const ProviderSignup: React.FC = () => {
 
     setIsLoading(true);
     try {
-      await createCompany({ name: companyName, phone });
-      setCurrentStep('details');
+      const res = await createCompany({ name: companyName, phone }, authToken!);
+      if (res.success) {
+        setCurrentStep('details');
+      } else {
+        throw new Error(res.error || '');
+      }
     } catch (error) {
       toast({
         title: "خطا در ثبت شرکت",
@@ -153,16 +167,19 @@ export const ProviderSignup: React.FC = () => {
 
     setIsLoading(true);
     try {
-      await createProvider({
+      const res = await createProvider({
         name: companyName,
         phone,
         radius_km: parseInt(radius),
         categories: selectedCategories,
         is_24_7: is24_7,
         vehicle_types: selectedVehicleTypes
-      });
-      
-      navigate('/signup/success');
+      }, authToken!);
+      if (res.success) {
+        navigate('/signup/success');
+      } else {
+        throw new Error(res.error || '');
+      }
     } catch (error) {
       toast({
         title: "خطا در ثبت‌نام",


### PR DESCRIPTION
## Summary
- convert API client to call backend endpoints for OTP, company and provider registration
- capture JWT token during provider signup and use it when saving company and provider info

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b934c761ac8328a11fefcf77b94f84