### PR TITLE
Improve OTP request error handling

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -229,13 +229,22 @@ class ApiClient {
         },
         ...options,
       });
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      let data: unknown = null;
+      try {
+        data = await response.json();
+      } catch (e) {
+        // ignore JSON parse errors
       }
 
-      const data = await response.json();
-      return { success: true, data };
+      if (!response.ok) {
+        const errData = data as { message?: string; error?: string } | null;
+        const message =
+          (errData && (errData.message || errData.error)) ||
+          `HTTP ${response.status}: ${response.statusText}`;
+        return { success: false, error: message };
+      }
+
+      return { success: true, data: data as T };
     } catch (error) {
       console.error('API Error:', error);
       return {

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -61,7 +61,15 @@ export const ProviderSignup: React.FC = () => {
           description: "کد ۶ رقمی به شماره شما پیامک شد",
         });
       } else {
-        throw new Error(res.error || '');
+        let description = "لطفاً دوباره تلاش کنید";
+        if (res.error?.includes("OTP recently requested")) {
+          description = "کد تأیید قبلاً ارسال شده است. لطفاً لحظاتی بعد دوباره تلاش کنید";
+        }
+        toast({
+          title: "خطا در ارسال کد",
+          description,
+          variant: "destructive",
+        });
       }
     } catch (error) {
       toast({


### PR DESCRIPTION
## Summary
- propagate API error messages from `request` helper
- show specific toast when OTP is requested too frequently

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9383d77c883289011621ed95f3172