### PR TITLE
Normalize phone numbers before requesting OTP

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,30 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function toEnglishDigits(input: string): string {
+  const map: Record<string, string> = {
+    "۰": "0",
+    "۱": "1",
+    "۲": "2",
+    "۳": "3",
+    "۴": "4",
+    "۵": "5",
+    "۶": "6",
+    "۷": "7",
+    "۸": "8",
+    "۹": "9",
+    "٠": "0",
+    "١": "1",
+    "٢": "2",
+    "٣": "3",
+    "٤": "4",
+    "٥": "5",
+    "٦": "6",
+    "٧": "7",
+    "٨": "8",
+    "٩": "9",
+  }
+
+  return input.replace(/[۰-۹٠-٩]/g, (d) => map[d] || d)
+}

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider, createCompany } from '@/lib/api';
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { toEnglishDigits } from '@/lib/utils';
 
 export const ProviderSignup: React.FC = () => {
   const navigate = useNavigate();
@@ -42,10 +43,11 @@ export const ProviderSignup: React.FC = () => {
   const [selectedVehicleTypes, setSelectedVehicleTypes] = useState<VehicleType[]>([]);
 
   const handleSendOTP = async () => {
-    if (!phone.trim()) {
+    const normalizedPhone = toEnglishDigits(phone).replace(/\D/g, '');
+    if (normalizedPhone.length !== 11) {
       toast({
         title: "خطا",
-        description: "لطفاً شماره تلفن را وارد کنید",
+        description: "لطفاً شماره تلفن معتبر وارد کنید",
         variant: "destructive",
       });
       return;
@@ -53,8 +55,9 @@ export const ProviderSignup: React.FC = () => {
 
     setIsLoading(true);
     try {
-      const res = await requestOTP(phone);
+      const res = await requestOTP(normalizedPhone);
       if (res.success) {
+        setPhone(normalizedPhone);
         setCurrentStep('otp');
         toast({
           title: "کد تأیید ارسال شد",
@@ -250,14 +253,18 @@ export const ProviderSignup: React.FC = () => {
                     type="tel"
                     placeholder="09123456789"
                     value={phone}
-                    onChange={(e) => setPhone(e.target.value)}
+                    onChange={(e) =>
+                      setPhone(
+                        toEnglishDigits(e.target.value).replace(/\D/g, '')
+                      )
+                    }
                     className="ltr text-right"
                     maxLength={11}
                   />
                 </div>
-                <Button 
+                <Button
                   onClick={handleSendOTP}
-                  disabled={isLoading || !phone.trim()}
+                  disabled={isLoading || phone.length !== 11}
                   className="w-full"
                   size="lg"
                 >


### PR DESCRIPTION
## Summary
- add helper to convert Persian/Arabic numerals to English digits
- sanitize provider signup phone input and validate before requesting OTP

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b93e560e088328a06bea96d5100cb3