### PR TITLE
Add company creation endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,9 +34,11 @@ def create_app():
 
     from .api.auth import bp as auth_bp
     from .api.providers import bp as providers_bp
+    from .api.company import bp as company_bp
 
     app.register_blueprint(auth_bp, url_prefix="/auth")
     app.register_blueprint(providers_bp, url_prefix="/providers")
+    app.register_blueprint(company_bp, url_prefix="/company")
 
     @app.route("/")
     def index():

--- a/app/api/company.py
+++ b/app/api/company.py
@@ -1,0 +1,24 @@
+"""Company creation endpoint."""
+from flask import Blueprint, request
+
+from ..db import get_db
+from ..models import Company
+from ..utils.errors import json_error
+
+bp = Blueprint("company", __name__)
+
+
+@bp.post("/")
+def create_company():
+    """Create a new company with phone and name."""
+    data = request.get_json() or {}
+    phone = data.get("phone")
+    name = data.get("name")
+    if not phone or not name:
+        return json_error("invalid_request", "phone and name required")
+    db = get_db()
+    company = Company(phone=phone, name=name)
+    db.add(company)
+    db.commit()
+    db.refresh(company)
+    return {"message": "company created", "id": company.id}

--- a/app/api/providers.py
+++ b/app/api/providers.py
@@ -50,11 +50,11 @@ def register_company():
         return json_error("phone_mismatch", "phone mismatch", 401)
 
     db = get_db()
-    company = db.execute(select(Company).where(Company.tel == phone)).scalar_one_or_none()
+    company = db.execute(select(Company).where(Company.phone == phone)).scalar_one_or_none()
     if company:
         company.name = name
     else:
-        company = Company(name=name, tel=phone)
+        company = Company(name=name, phone=phone)
         db.add(company)
     db.commit()
     return {"id": company.id}
@@ -114,11 +114,11 @@ def register_provider():
     if len(vehicles_db) != len(set(veh_slugs)):
         return json_error("unknown_vehicle_type", "unknown vehicle type")
 
-    company = db.execute(select(Company).where(Company.tel == phone)).scalar_one_or_none()
+    company = db.execute(select(Company).where(Company.phone == phone)).scalar_one_or_none()
     if company:
         company.name = name
     else:
-        company = Company(name=name, tel=phone)
+        company = Company(name=name, phone=phone)
         db.add(company)
 
     point = WKTElement(f"POINT({lon} {lat})", srid=4326)

--- a/app/models.py
+++ b/app/models.py
@@ -36,7 +36,7 @@ class Company(Base):
     __tablename__ = "company"
 
     id = Column(Integer, primary_key=True)
-    tel = Column(String(20), unique=True, nullable=False)
+    phone = Column(String(20), unique=True, nullable=False)
     name = Column(String(255), nullable=False)
 
 

--- a/migrations/versions/0003_create_company_table.py
+++ b/migrations/versions/0003_create_company_table.py
@@ -14,7 +14,7 @@ def upgrade() -> None:
     op.create_table(
         "company",
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("tel", sa.String(length=20), nullable=False, unique=True),
+        sa.Column("phone", sa.String(length=20), nullable=False, unique=True),
         sa.Column("name", sa.String(length=255), nullable=False),
     )
 


### PR DESCRIPTION
## Summary
- add Company model phone column
- add /company POST route to store name and phone
- register company blueprint and update providers usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb01c863e08328b36a3570f10b53c0