### PR TITLE
feat: add company creation endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+FLASK_ENV=development
+FLASK_APP=backend.app
+SQLALCHEMY_DATABASE_URI=mssql+pyodbc://sa:Sa123sa@localhost:1433/Marketplace?driver=ODBC+Driver+17+for+SQL+Server&TrustServerCertificate=yes

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,34 +1,22 @@
-import os
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-from dotenv import load_dotenv
 
 
 db = SQLAlchemy()
-migrate = None
-
+migrate = Migrate()
 
 def create_app():
-    load_dotenv()  # .env را لود کن
     app = Flask(__name__)
-    app.config.from_object("config.Config")
+    app.config.from_object("backend.config.Config")
 
     db.init_app(app)
-    global migrate
-    migrate = Migrate(app, db)
+    migrate.init_app(app, db)
 
-    # ثبت بلوپرینت ها
-    from .routes.company import bp as company_bp
-    app.register_blueprint(company_bp, url_prefix="/")
-
-    # ساخت جداول در صورت نبود (برای Dev)
-    with app.app_context():
-        from .models.company import Company  # اطمینان از import مدل
-        db.create_all()
-
-    @app.get("/health")
-    def health():
-        return {"status": "ok"}
+    # مدل‌ها را ایمپورت کن تا Alembic ببیند
+    from backend.models import Company  # noqa: F401
+    # ثبت روت‌ها
+    from backend.routes import api_bp
+    app.register_blueprint(api_bp, url_prefix="/")
 
     return app

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,9 +1,9 @@
 import os
+from dotenv import load_dotenv
+load_dotenv()
 
 class Config:
-    SQLALCHEMY_DATABASE_URI = os.getenv(
-        "SQLALCHEMY_DATABASE_URI",
-        "sqlite:///app.db"  # fallback فقط برای توسعه بدون سرور
-    )
+    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
+    if not SQLALCHEMY_DATABASE_URI:
+        raise RuntimeError("SQLALCHEMY_DATABASE_URI is not set")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_ECHO = os.getenv("SQLALCHEMY_ECHO", "false").lower() == "true"

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,10 @@
+from backend.app import db
+
+
+class Company(db.Model):
+    __tablename__ = "Company"
+    __table_args__ = {"schema": "dbo"}  # پیش‌فرض SQL Server
+
+    Id   = db.Column("Id",  db.Integer, primary_key=True, autoincrement=True)
+    Tel  = db.Column("Tel", db.String(20),  nullable=False, unique=True)
+    Name = db.Column("Name", db.String(255), nullable=False)

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, request, jsonify
+from backend.app import db
+from backend.models import Company
+
+api_bp = Blueprint("api", __name__)
+
+
+@api_bp.route("/company", methods=["POST"])
+def create_company():
+    data = request.get_json(silent=True) or {}
+    tel  = (data.get("phone") or data.get("tel") or "").strip()
+    name = (data.get("name") or "").strip()
+
+    if not tel or not name:
+        return jsonify({"error": "tel/phone و name الزامی است"}), 400
+
+    if Company.query.filter_by(Tel=tel).first():
+        return jsonify({"error": "tel تکراری است"}), 409
+
+    c = Company(Tel=tel, Name=name)
+    db.session.add(c)
+    db.session.commit()
+    return jsonify({"id": c.Id, "status": "ok"})


### PR DESCRIPTION
## Summary
- configure Flask app via environment
- add SQL Server `Company` model and POST route

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*
- `pip install Flask Flask-SQLAlchemy Flask-Migrate python-dotenv` *(fails: Could not find a version that satisfies the requirement Flask-SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68bb58d3394883288e9f08c9f22db14e