### PR TITLE
feat: change development port to 1743

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ npm install
 npm run dev
 ```
 
+The development server runs on `http://localhost:1743`.
+
 The frontend expects the backend on `http://localhost:5000`.
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - MSSQL_URI=mssql+pyodbc://sa:YourStrong!Passw0rd@db:1433/tempdb?driver=ODBC+Driver+17+for+SQL+Server
       - JWT_SECRET=change-me
-      - FRONTEND_ORIGINS=http://localhost:5173
+      - FRONTEND_ORIGINS=http://localhost:1743
     ports:
       - "5000:5000"
     depends_on:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
-    port: 8080,
+    port: 1743,
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- run frontend dev server on port 1743
- adjust docker compose frontend origin to match new port
- document frontend port in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc3540fcb483289e5a196ce7ab7df6