### PR TITLE
Update homepage title and heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
-    <title>امداد کامیون - خدمات اضطراری و تعمیرات سنگین</title>
+    <title>بازارگاه خدمات اضطراری و تعمیرات خودروهای سنگین</title>
     <meta name="description" content="پلتفرم جامع خدمات اضطراری و تعمیرات کامیون - یافتن نزدیک‌ترین ارائه‌دهندگان خدمات سنگین" />
     <meta name="author" content="TruckAid Team" />
     <meta name="keywords" content="کامیون، تعمیرات، امداد، یدک‌کش، لاستیک، خدمات جاده‌ای" />
@@ -13,20 +13,20 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="امداد کامیون" />
+    <meta name="apple-mobile-web-app-title" content="بازارگاه خدمات اضطراری و تعمیرات خودروهای سنگین" />
     
     <!-- Preconnect for fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
-    <meta property="og:title" content="امداد کامیون - خدمات اضطراری و تعمیرات سنگین" />
+    <meta property="og:title" content="بازارگاه خدمات اضطراری و تعمیرات خودروهای سنگین" />
     <meta property="og:description" content="پلتفرم جامع خدمات اضطراری و تعمیرات کامیون" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="fa_IR" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="امداد کامیون" />
+    <meta name="twitter:title" content="بازارگاه خدمات اضطراری و تعمیرات خودروهای سنگین" />
     <meta name="twitter:description" content="خدمات اضطراری و تعمیرات سنگین" />
   </head>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,7 +9,10 @@ const Index = () => {
   ];
 
   return (
-    <div className="min-h-screen flex items-center justify-center gradient-hero">
+    <div className="min-h-screen flex flex-col items-center justify-center gradient-hero">
+      <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">
+        بازارگاه خدمات اضطراری و تعمیرات خودروهای سنگین
+      </h1>
       <div className="grid grid-cols-2 gap-4 w-full max-w-md p-4">
         {menuItems.map((item) => (
           <Link


### PR DESCRIPTION
## Summary
- rename site title to "بازارگاه خدمات اضطراری و تعمیرات خودروهای سنگین"
- display same title prominently on the landing page

## Testing
- `npm test` (missing script: "test")
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc615ef38483289278be9dd8318198