### PR TITLE
feat: unify hero styling and add text shadow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -188,4 +188,8 @@
     min-height: 44px;
     min-width: 44px;
   }
+
+  .text-shadow-white {
+    text-shadow: 0 0 4px rgba(255,255,255,0.8);
+  }
 }

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -185,9 +185,11 @@ export const CategoryPage: React.FC = () => {
       <Header title={categoryInfo.title} />
       
       {/* Category Info */}
-      <div className="bg-gradient-primary text-white p-4 text-center">
-        <h2 className="text-lg font-semibold mb-1">{categoryInfo.title}</h2>
-        <p className="text-sm opacity-90">{categoryInfo.subtitle}</p>
+      <div className="gradient-hero text-white p-6 text-center">
+        <div className="max-w-md mx-auto">
+          <h2 className="text-xl font-bold mb-1 text-shadow-white">{categoryInfo.title}</h2>
+          <p className="text-sm opacity-90 text-shadow-white">{categoryInfo.subtitle}</p>
+        </div>
       </div>
       
       {/* Filter Bar */}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -33,8 +33,8 @@ export const SearchPage: React.FC = () => {
       <div className="gradient-hero text-white p-6 text-center">
         <div className="max-w-md mx-auto">
           <Truck size={48} className="mx-auto mb-4" />
-          <h1 className="text-2xl font-bold mb-2">امداد کامیون</h1>
-          <p className="opacity-90">خدمات اضطراری و تعمیرات سنگین</p>
+          <h1 className="text-2xl font-bold mb-2 text-shadow-white">امداد کامیون</h1>
+          <p className="opacity-90 text-shadow-white">خدمات اضطراری و تعمیرات سنگین</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add reusable white text shadow utility
- highlight home hero text with subtle white shadow
- match category page hero section to landing page styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc64a06d508328b4825869559c7605