### PR TITLE
feat: persist company signup

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -337,10 +337,14 @@ class ApiClient {
   async registerCompany(
     data: CompanyRegistration,
     token: string
-  ): Promise<ApiResponse<{ id: string }>> {
-    await new Promise(resolve => setTimeout(resolve, 600));
-
-    return { success: true, data: { id: '1' } };
+  ): Promise<ApiResponse<{ Id: number; Tel: string; Name: string }>> {
+    return this.request<{ Id: number; Tel: string; Name: string }>('/company', {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
   }
 
   // Register new provider

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -110,7 +110,10 @@ export const ProviderSignup: React.FC = () => {
 
     setIsLoading(true);
     try {
-      await createCompany({ name: companyName, phone });
+      const res = await createCompany({ name: companyName, phone });
+      if (!res.success) {
+        throw new Error(res.error || 'company creation failed');
+      }
       setCurrentStep('details');
     } catch (error) {
       toast({


### PR DESCRIPTION
## Summary
- connect frontend company registration to backend `/company` API
- handle company submission result before continuing signup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc6fe0c0688328ad4f2ef83ccbeb13