### PR TITLE
Show service categories in two-column layout

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -86,7 +86,7 @@ export const CategorySelector: React.FC<CategorySelectorProps> = ({
   }
 
   return (
-    <div className={`grid gap-3 ${className}`}>
+    <div className={`grid grid-cols-2 gap-3 ${className}`}>
       {categories.map((category) => {
         const Icon = category.icon;
         const categorySelected = isSelected(category.id);

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -128,10 +128,11 @@ export const ProviderSignup: React.FC = () => {
       const json = await res.json();
       localStorage.setItem('provider_company_id', String(json.id));
       setCurrentStep('details');
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'لطفاً دوباره تلاش کنید';
       toast({
         title: 'خطا در ثبت شرکت',
-        description: error.message || 'لطفاً دوباره تلاش کنید',
+        description: message,
         variant: 'destructive',
       });
     } finally {


### PR DESCRIPTION
## Summary
- Display service categories in a responsive two-column grid for easier selection
- Clean up provider signup error handling by removing explicit `any` type

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bd8b0959848328bc8f35e68caf7b96