### PR TITLE
feat: streamline dev startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,12 @@ npm install
 npm run dev
 ```
 
-The development server runs on `http://localhost:1743`.
+`npm run dev` now starts both the frontend (Vite) and the Flask backend together.
+If you want to run only the React app you can use `npm run frontend`, and the
+API alone can be started with `npm run backend`.
 
-The frontend expects the backend on `http://localhost:5000`.
+The Vite dev server runs on `http://localhost:1743` and the backend listens on
+`http://localhost:5000`.
 
 ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,6 @@
+from backend.app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "start": "node start.js",
+    "dev": "node start.js",
+    "frontend": "vite",
+    "backend": "python -m backend.main",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/start.js
+++ b/start.js
@@ -1,0 +1,27 @@
+import { spawn } from 'child_process';
+
+const isWin = process.platform === 'win32';
+const npmCmd = isWin ? 'npm.cmd' : 'npm';
+
+const backend = spawn('python', ['-m', 'backend.main'], { stdio: 'inherit' });
+const frontend = spawn(npmCmd, ['run', 'frontend'], { stdio: 'inherit' });
+
+const processes = [backend, frontend];
+
+function shutdown(code) {
+  for (const proc of processes) {
+    if (!proc.killed) {
+      proc.kill('SIGINT');
+    }
+  }
+  if (code !== undefined) {
+    process.exit(code);
+  }
+}
+
+for (const proc of processes) {
+  proc.on('exit', (code) => shutdown(code ?? 0));
+}
+
+process.on('SIGINT', () => shutdown());
+process.on('SIGTERM', () => shutdown());


### PR DESCRIPTION
## Summary
- add start.js script to launch backend and frontend together
- expose backend app via backend/main.py
- document single-command startup and provide npm start alias

## Testing
- `npm run lint`
- `node --check start.js`
- `python -m py_compile backend/main.py`
- `npm run dev` (terminated after startup)


------
https://chatgpt.com/codex/tasks/task_e_68c3a3db20dc8328b973a6faa232e1bc