### PR TITLE
feat: add single dev command for frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,18 @@ Environment variables (`MSSQL_URI`, `JWT_SECRET`, `FRONTEND_ORIGINS`) can be adj
 
 ```bash
 npm install
+
+# run frontend only
+npm run frontend
+
+# run backend only
+npm run backend
+
+# run both concurrently
 npm run dev
 ```
 
-The development server runs on `http://localhost:1743`.
-
-The frontend expects the backend on `http://localhost:5000`.
+The Vite development server runs on `http://localhost:1743` and the Flask backend on `http://localhost:5000`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "frontend": "vite",
+    "backend": "python -m flask --app backend.app:create_app --debug run",
+    "dev": "npm run backend & npm run frontend & wait",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- add npm scripts to run Flask backend and Vite frontend together
- document new `npm run dev`, `frontend`, and `backend` commands

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c3a70ef83c8328b953b88d9d48684f