### PR TITLE
Add web.config for IIS SPA hosting

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <mimeMap fileExtension=".json" mimeType="application/json" />
+    </staticContent>
+    <rewrite>
+      <rules>
+        <rule name="ReactRouter" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/index.html" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>

--- a/public/web.config
+++ b/public/web.config
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.webServer>
-    <handlers>
-      <remove name="Python FastCGI" />
-      <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
-    </handlers>
     <defaultDocument>
       <files>
         <add value="index.html" />

--- a/public/web.config
+++ b/public/web.config
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.webServer>
+    <handlers>
+      <remove name="Python FastCGI" />
+      <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
+    </handlers>
+    <defaultDocument>
+      <files>
+        <add value="index.html" />
+      </files>
+    </defaultDocument>
     <staticContent>
       <mimeMap fileExtension=".json" mimeType="application/json" />
     </staticContent>


### PR DESCRIPTION
## Summary
- add web.config to include rewrite rules for hosting the Vite/React build on IIS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c54960f1508328b811035252400922