### PR TITLE
Use environment-based API URL for company registration

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
-const API_BASE_URL =
+export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
-  `${window.location.protocol}//${window.location.hostname}:5000/api`;
+  `${window.location.origin}/api`;
 
 interface ApiResponse<T = unknown> {
   success: boolean;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
-  `${window.location.origin}/api`;
+  window.location.origin;
 
 interface ApiResponse<T = unknown> {
   success: boolean;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  `${window.location.protocol}//${window.location.hostname}:5000/api`;
 
 interface ApiResponse<T = unknown> {
   success: boolean;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // API Layer for Heavy Vehicle Service PWA
 export const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL ||
-  window.location.origin;
+  (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '') ||
+  `${window.location.protocol}//${window.location.hostname}:5000`;
 
 interface ApiResponse<T = unknown> {
   success: boolean;

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -13,7 +13,9 @@ import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider } f
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:5000';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  `${window.location.protocol}//${window.location.hostname}:5000`;
 
 export const ProviderSignup: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -13,6 +13,8 @@ import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider } f
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:5000';
+
 export const ProviderSignup: React.FC = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -116,7 +118,7 @@ export const ProviderSignup: React.FC = () => {
       if (!storedPhone) {
         throw new Error('شماره تلفن یافت نشد؛ مرحله قبل را کامل کنید');
       }
-      const res = await fetch('http://127.0.0.1:5000/company', {
+      const res = await fetch(`${API_BASE_URL}/company`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone: storedPhone, name }),

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -9,13 +9,16 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { CategorySelector } from '@/components/CategorySelector';
 import { Header } from '@/components/Header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider } from '@/lib/api';
+import {
+  ServiceCategory,
+  VehicleType,
+  requestOTP,
+  verifyOTP,
+  createProvider,
+  API_BASE_URL,
+} from '@/lib/api';
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-
-const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL ||
-  `${window.location.protocol}//${window.location.hostname}:5000`;
 
 export const ProviderSignup: React.FC = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- Allow frontend to read API base URL from `VITE_API_BASE_URL`
- Use this configurable URL for the company creation request

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c695f55c048328b42ddaf5a397be6a