### PR TITLE
Normalize MSSQL server port handling

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,17 +1,38 @@
 import os
+from typing import Optional
 
 MSSQL_SERVER   = os.getenv("MSSQL_SERVER",   "185.10.75.107")
+MSSQL_PORT     = os.getenv("MSSQL_PORT")
 MSSQL_DATABASE = os.getenv("MSSQL_DATABASE", "Marketplace")
 MSSQL_USER     = os.getenv("MSSQL_USER",     "sa")
 MSSQL_PASSWORD = os.getenv("MSSQL_PASSWORD", "REPLACE_WITH_REAL_PASSWORD")
 MSSQL_DRIVER   = os.getenv("MSSQL_DRIVER",   "ODBC Driver 17 for SQL Server")
 
 
+def _normalize_server(server: str, port: Optional[str] = None) -> str:
+    """Ensure the server section of the URI uses ``host:port`` when needed."""
+
+    server = server.strip()
+
+    # Explicit port from env has the highest priority.
+    if port:
+        return f"{server}:{port.strip()}"
+
+    # SQL Server connection strings often specify the port with a comma
+    # (e.g. ``127.0.0.1,1433``). SQLAlchemy expects the URI format with
+    # a colon, so we convert the first comma to a colon when no colon is present.
+    if "," in server and ":" not in server:
+        host, port_part = server.split(",", 1)
+        return f"{host}:{port_part}"
+
+    return server
+
+
 class Config:
     SQLALCHEMY_DATABASE_URI = os.getenv(
         "SQLALCHEMY_DATABASE_URI",
         f"mssql+pyodbc://{MSSQL_USER}:{MSSQL_PASSWORD}"
-        f"@{MSSQL_SERVER}/{MSSQL_DATABASE}"
+        f"@{_normalize_server(MSSQL_SERVER, MSSQL_PORT)}/{MSSQL_DATABASE}"
         f"?driver={MSSQL_DRIVER.replace(' ', '+')}&TrustServerCertificate=yes"
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
## Summary
- allow configuring the SQL Server port via a dedicated `MSSQL_PORT` environment variable
- normalize SQL Server host strings that use the comma-separated host,port syntax into the URI-friendly host:port format

## Testing
- not run (reason: configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca7015d1b0832893cd991d764ef88c