### PR TITLE
Allow configuring SQLAlchemy URI via MSSQL_URI

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -7,13 +7,19 @@ MSSQL_PASSWORD = os.getenv("MSSQL_PASSWORD", "REPLACE_WITH_REAL_PASSWORD")
 MSSQL_DRIVER   = os.getenv("MSSQL_DRIVER",   "ODBC Driver 17 for SQL Server")
 
 
-class Config:
-    SQLALCHEMY_DATABASE_URI = os.getenv(
-        "SQLALCHEMY_DATABASE_URI",
+def _build_default_uri() -> str:
+    """Compose the fallback SQLAlchemy connection URI."""
+
+    driver = MSSQL_DRIVER.replace(" ", "+")
+    return (
         f"mssql+pyodbc://{MSSQL_USER}:{MSSQL_PASSWORD}"
-        f"@{MSSQL_SERVER}/{MSSQL_DATABASE}"
-        f"?driver={MSSQL_DRIVER.replace(' ', '+')}&TrustServerCertificate=yes"
+        f"@{MSSQL_SERVER}/{MSSQL_DATABASE}?driver={driver}&TrustServerCertificate=yes"
     )
+
+
+class Config:
+    _uri_from_env = os.getenv("SQLALCHEMY_DATABASE_URI") or os.getenv("MSSQL_URI")
+    SQLALCHEMY_DATABASE_URI = _uri_from_env or _build_default_uri()
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     JSON_AS_ASCII = False
     SQLALCHEMY_ECHO = os.getenv("SQLALCHEMY_ECHO", "false").lower() == "true"


### PR DESCRIPTION
## Summary
- add helper to compose default SQL Server connection string
- allow overriding SQLALCHEMY_DATABASE_URI via MSSQL_URI env var

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cad63116d88328a0d1758d6ac8ff41