### PR TITLE
Refactor API base URL handling

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 // API Layer for Heavy Vehicle Service PWA
-import { API_BASE as API_BASE_URL } from '../utils/api';
+import { apiFetch } from '../utils/api';
 
 interface ApiResponse<T = unknown> {
   success: boolean;
@@ -218,23 +218,13 @@ class ApiClient {
     options: RequestInit = {}
   ): Promise<ApiResponse<T>> {
     try {
-      if (!API_BASE_URL) {
-        console.error('VITE_API_BASE_URL is not defined');
-        throw new Error('API base URL is not defined');
-      }
-      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+      const data = await apiFetch<T>(endpoint, {
         headers: {
           'Content-Type': 'application/json',
           ...options.headers,
         },
         ...options,
       });
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const data = await response.json();
       return { success: true, data };
     } catch (error) {
       console.error('API Error:', error);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 // API Layer for Heavy Vehicle Service PWA
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
+import { API_BASE as API_BASE_URL } from '../utils/api';
 
 interface ApiResponse<T = unknown> {
   success: boolean;
@@ -218,6 +218,10 @@ class ApiClient {
     options: RequestInit = {}
   ): Promise<ApiResponse<T>> {
     try {
+      if (!API_BASE_URL) {
+        console.error('VITE_API_BASE_URL is not defined');
+        throw new Error('API base URL is not defined');
+      }
       const response = await fetch(`${API_BASE_URL}${endpoint}`, {
         headers: {
           'Content-Type': 'application/json',

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -10,6 +10,7 @@ import { CategorySelector } from '@/components/CategorySelector';
 import { Header } from '@/components/Header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider } from '@/lib/api';
+import { apiFetch } from '@/utils/api';
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
@@ -116,16 +117,11 @@ export const ProviderSignup: React.FC = () => {
       if (!storedPhone) {
         throw new Error('شماره تلفن یافت نشد؛ مرحله قبل را کامل کنید');
       }
-      const res = await fetch('http://127.0.0.1:5000/company', {
+      const json = await apiFetch<{ id: number }>('/api/signup/company', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone: storedPhone, name }),
       });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.error || `HTTP ${res.status}`);
-      }
-      const json = await res.json();
       localStorage.setItem('provider_company_id', String(json.id));
       setCurrentStep('details');
     } catch (error) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,13 +1,61 @@
 export const API_BASE = import.meta.env.VITE_API_BASE_URL;
-if (!API_BASE) console.error("VITE_API_BASE_URL is not defined");
+if (!API_BASE) console.error('VITE_API_BASE_URL is not defined');
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+const ensureLeadingSlash = (value: string) => (value.startsWith('/') ? value : `/${value}`);
+
+const extractErrorMessage = (payload: unknown, fallback: string) => {
+  if (!payload) return fallback;
+
+  if (typeof payload === 'string') {
+    return payload.trim() || fallback;
+  }
+
+  if (typeof payload === 'object') {
+    const messageLike =
+      // @ts-expect-error index signature not declared on purpose
+      payload?.message ?? payload?.detail ?? payload?.error ?? payload?.errors;
+    if (Array.isArray(messageLike)) {
+      return messageLike.map(item => (typeof item === 'string' ? item : '')).join('\n') || fallback;
+    }
+    if (messageLike) {
+      return String(messageLike);
+    }
+  }
+
+  return fallback;
+};
 
 export async function apiFetch<T = unknown>(path: string, init?: RequestInit): Promise<T> {
   if (!API_BASE) {
-    console.error("Cannot perform request without API base URL");
-    throw new Error("API base URL is not defined");
+    console.error('Cannot perform request without API base URL');
+    throw new Error('آدرس سرور تنظیم نشده است');
   }
 
-  const res = await fetch(`${API_BASE}${path}`, init);
-  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
-  return res.json() as Promise<T>;
+  const url = `${trimTrailingSlash(API_BASE)}${ensureLeadingSlash(path)}`;
+  const response = await fetch(url, init);
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const expectsJson = contentType.includes('application/json');
+
+  let payload: unknown = undefined;
+  if (response.status !== 204) {
+    try {
+      if (expectsJson) {
+        payload = await response.json();
+      } else {
+        const text = await response.text();
+        payload = text ? text : undefined;
+      }
+    } catch (error) {
+      console.error('Failed to parse API response', error);
+    }
+  }
+
+  if (!response.ok) {
+    const fallbackMessage = `HTTP ${response.status} ${response.statusText}`;
+    throw new Error(extractErrorMessage(payload, fallbackMessage));
+  }
+
+  return (payload as T) ?? (undefined as T);
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -27,12 +27,12 @@ const extractErrorMessage = (payload: unknown, fallback: string) => {
 };
 
 export async function apiFetch<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+  const base = API_BASE ? trimTrailingSlash(API_BASE) : '';
   if (!API_BASE) {
     console.error('Cannot perform request without API base URL');
-    throw new Error('آدرس سرور تنظیم نشده است');
   }
 
-  const url = `${trimTrailingSlash(API_BASE)}${ensureLeadingSlash(path)}`;
+  const url = `${base}${ensureLeadingSlash(path)}`;
   const response = await fetch(url, init);
 
   const contentType = response.headers.get('content-type') ?? '';

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,13 @@
+export const API_BASE = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE) console.error("VITE_API_BASE_URL is not defined");
+
+export async function apiFetch<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+  if (!API_BASE) {
+    console.error("Cannot perform request without API base URL");
+    throw new Error("API base URL is not defined");
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, init);
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  return res.json() as Promise<T>;
+}


### PR DESCRIPTION
## Summary
- add a shared API utility that reads the base URL from VITE_API_BASE_URL and validates configuration
- update the API client to rely on the shared base URL and log configuration errors before requests
- reuse the shared fetch helper on the provider signup flow instead of hardcoding local URLs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cafb1ad43483289fba01ec4976d18e