### PR TITLE
Skip company API call during signup

### DIFF
--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -10,7 +10,6 @@ import { CategorySelector } from '@/components/CategorySelector';
 import { Header } from '@/components/Header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider } from '@/lib/api';
-import { apiFetch } from '@/utils/api';
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
@@ -100,7 +99,7 @@ export const ProviderSignup: React.FC = () => {
     }
   };
 
-  const handleCompanySubmit = async () => {
+  const handleCompanySubmit = () => {
     if (!companyName.trim()) {
       toast({
         title: "خطا",
@@ -109,31 +108,7 @@ export const ProviderSignup: React.FC = () => {
       });
       return;
     }
-
-    setIsLoading(true);
-    try {
-      const storedPhone = localStorage.getItem('provider_phone') || '';
-      const name = companyName.trim();
-      if (!storedPhone) {
-        throw new Error('شماره تلفن یافت نشد؛ مرحله قبل را کامل کنید');
-      }
-      const json = await apiFetch<{ id: number }>('/api/signup/company', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone: storedPhone, name }),
-      });
-      localStorage.setItem('provider_company_id', String(json.id));
-      setCurrentStep('details');
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'لطفاً دوباره تلاش کنید';
-      toast({
-        title: 'خطا در ثبت شرکت',
-        description: message,
-        variant: 'destructive',
-      });
-    } finally {
-      setIsLoading(false);
-    }
+    setCurrentStep('details');
   };
 
   const handleSubmit = async () => {


### PR DESCRIPTION
## Summary
- remove the company signup API call so clicking continue simply advances to the next step
- keep validation on the company name before proceeding to the details step

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd45d24fc88328a511dfff916e00d6