### PR TITLE
Store provider signup details on final submission

### DIFF
--- a/backend/models/company.py
+++ b/backend/models/company.py
@@ -8,3 +8,28 @@ class Company(db.Model):
     Id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
     Tel = db.Column(db.String(50), nullable=False)
     Name = db.Column(db.String(100), nullable=False)
+    Type_Of_Service = db.Column(db.String(255), nullable=True)
+    Radius_Of_Activity = db.Column(db.Integer, nullable=True)
+    Working_Hours = db.Column(db.String(100), nullable=True)
+    Vehicle_Type = db.Column(db.String(255), nullable=True)
+    Date = db.Column(db.DateTime, nullable=True)
+
+    def update_details(
+        self,
+        *,
+        type_of_service=None,
+        radius_of_activity=None,
+        working_hours=None,
+        vehicle_type=None,
+        date_value=None,
+    ):
+        if type_of_service is not None:
+            self.Type_Of_Service = type_of_service
+        if radius_of_activity is not None:
+            self.Radius_Of_Activity = radius_of_activity
+        if working_hours is not None:
+            self.Working_Hours = working_hours
+        if vehicle_type is not None:
+            self.Vehicle_Type = vehicle_type
+        if date_value is not None:
+            self.Date = date_value

--- a/backend/routes/company.py
+++ b/backend/routes/company.py
@@ -1,8 +1,68 @@
+from datetime import date as date_cls, datetime
+
 from flask import Blueprint, request, jsonify
+
 from ..app import db
 from ..models.company import Company
 
-bp = Blueprint("company", __name__)
+bp = Blueprint("company", __name__, url_prefix="/api/signup")
+
+
+def _prepare_company_details(data, *, include_default_date: bool) -> dict:
+    type_of_service = (
+        (data.get("type_of_service") or data.get("Type_Of_Service") or "")
+        .strip()
+        or None
+    )
+
+    radius_of_activity = data.get("radius_of_activity") or data.get("Radius_Of_Activity")
+    if isinstance(radius_of_activity, str):
+        radius_of_activity = radius_of_activity.strip()
+        radius_of_activity = int(radius_of_activity) if radius_of_activity else None
+    elif radius_of_activity is not None:
+        try:
+            radius_of_activity = int(radius_of_activity)
+        except (TypeError, ValueError):
+            radius_of_activity = None
+
+    working_hours = (
+        (data.get("working_hours") or data.get("Working_Hours") or "")
+        .strip()
+        or None
+    )
+
+    vehicle_type = data.get("vehicle_type") or data.get("Vehicle_Type")
+    if isinstance(vehicle_type, (list, tuple)):
+        vehicle_type = ", ".join(str(item) for item in vehicle_type if str(item).strip()) or None
+    elif isinstance(vehicle_type, str):
+        vehicle_type = vehicle_type.strip() or None
+    else:
+        vehicle_type = None
+
+    raw_date = data.get("date") or data.get("Date")
+    parsed_date = None
+    if isinstance(raw_date, datetime):
+        parsed_date = raw_date
+    elif isinstance(raw_date, date_cls):
+        parsed_date = datetime.combine(raw_date, datetime.min.time())
+    elif isinstance(raw_date, str) and raw_date.strip():
+        cleaned = raw_date.strip()
+        cleaned = cleaned.replace("Z", "+00:00") if cleaned.endswith("Z") else cleaned
+        try:
+            parsed_date = datetime.fromisoformat(cleaned)
+        except ValueError:
+            parsed_date = None
+
+    if parsed_date is None and include_default_date:
+        parsed_date = datetime.utcnow()
+
+    return {
+        "type_of_service": type_of_service,
+        "radius_of_activity": radius_of_activity,
+        "working_hours": working_hours,
+        "vehicle_type": vehicle_type,
+        "date_value": parsed_date,
+    }
 
 
 @bp.route("/company", methods=["POST"])
@@ -22,10 +82,38 @@ def create_company():
         return jsonify({"error": "name و phone الزامی هستند"}), 400
 
     try:
+        details = _prepare_company_details(data, include_default_date=False)
         company = Company(Tel=phone, Name=name)
+        company.update_details(**details)
         db.session.add(company)
         db.session.commit()
-        return jsonify({"id": company.Id, "message": "company created"}), 201
+        return (
+            jsonify(
+                {
+                    "id": company.Id,
+                    "message": "company created",
+                }
+            ),
+            201,
+        )
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 500
+
+
+@bp.route("/company/<int:company_id>", methods=["PUT"])
+def update_company(company_id: int):
+    data = request.get_json(silent=True) or {}
+    company = Company.query.get(company_id)
+    if not company:
+        return jsonify({"error": "company not found"}), 404
+
+    details = _prepare_company_details(data, include_default_date=True)
+
+    try:
+        company.update_details(**details)
+        db.session.commit()
+        return jsonify({"id": company.Id, "message": "company updated"}), 200
     except Exception as e:
         db.session.rollback()
         return jsonify({"error": str(e)}), 500

--- a/migrations/versions/0002_add_company_details_fields.py
+++ b/migrations/versions/0002_add_company_details_fields.py
@@ -1,0 +1,28 @@
+"""add additional company detail fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("Company", sa.Column("Type_Of_Service", sa.String(length=255), nullable=True), schema="dbo")
+    op.add_column("Company", sa.Column("Radius_Of_Activity", sa.Integer(), nullable=True), schema="dbo")
+    op.add_column("Company", sa.Column("Working_Hours", sa.String(length=100), nullable=True), schema="dbo")
+    op.add_column("Company", sa.Column("Vehicle_Type", sa.String(length=255), nullable=True), schema="dbo")
+    op.add_column("Company", sa.Column("Date", sa.DateTime(), nullable=True), schema="dbo")
+
+
+def downgrade() -> None:
+    op.drop_column("Company", "Date", schema="dbo")
+    op.drop_column("Company", "Vehicle_Type", schema="dbo")
+    op.drop_column("Company", "Working_Hours", schema="dbo")
+    op.drop_column("Company", "Radius_Of_Activity", schema="dbo")
+    op.drop_column("Company", "Type_Of_Service", schema="dbo")
+

--- a/src/pages/ProviderSignup.tsx
+++ b/src/pages/ProviderSignup.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { CategorySelector } from '@/components/CategorySelector';
 import { Header } from '@/components/Header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ServiceCategory, VehicleType, requestOTP, verifyOTP, createProvider } from '@/lib/api';
+import { ServiceCategory, VehicleType, requestOTP, verifyOTP } from '@/lib/api';
 import { apiFetch } from '@/utils/api';
 import { Phone, Building, Radius, Clock, Truck, Bus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
@@ -17,6 +17,19 @@ import { useToast } from '@/hooks/use-toast';
 export const ProviderSignup: React.FC = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
+
+  const categoryLabels: Record<ServiceCategory, string> = {
+    roadside: 'خدمات جاده‌ای',
+    tire: 'لاستیک و رینگ',
+    recovery: 'امداد و حادثه',
+    oil: 'فروش روغن و فیلتر',
+  };
+
+  const vehicleLabels: Record<VehicleType, string> = {
+    truck: 'کامیون',
+    semi: 'تریلی',
+    bus: 'اتوبوس',
+  };
   
   // Step management
   const [currentStep, setCurrentStep] =
@@ -166,20 +179,36 @@ export const ProviderSignup: React.FC = () => {
 
     setIsLoading(true);
     try {
-      await createProvider({
-        name: companyName,
-        phone,
-        radius_km: parseInt(radius),
-        categories: selectedCategory ? [selectedCategory] : [],
-        is_24_7: is24_7,
-        vehicle_types: selectedVehicleTypes
+      const companyId = localStorage.getItem('provider_company_id');
+      if (!companyId) {
+        throw new Error('شناسه شرکت یافت نشد؛ لطفاً مراحل قبلی را کامل کنید');
+      }
+
+      const typeOfService = selectedCategory ? categoryLabels[selectedCategory] : '';
+      const radiusValue = Number.parseInt(radius, 10);
+      const workingHours = is24_7 ? 'شبانه‌روزی' : 'غیر شبانه‌روزی';
+      const vehicleType = selectedVehicleTypes
+        .map(vehicle => vehicleLabels[vehicle])
+        .join(', ');
+
+      await apiFetch(`/api/signup/company/${companyId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type_of_service: typeOfService,
+          radius_of_activity: Number.isNaN(radiusValue) ? undefined : radiusValue,
+          working_hours: workingHours,
+          vehicle_type: vehicleType,
+          date: new Date().toISOString(),
+        }),
       });
-      
+
       navigate('/signup/success');
     } catch (error) {
       toast({
         title: "خطا در ثبت‌نام",
-        description: "لطفاً دوباره تلاش کنید",
+        description:
+          error instanceof Error ? error.message : "لطفاً دوباره تلاش کنید",
         variant: "destructive",
       });
     } finally {


### PR DESCRIPTION
## Summary
- extend the Company model and database schema with fields for service type, radius, working hours, vehicles, and submission date
- allow the company API to capture detailed information and provide an endpoint for final registration updates
- send the collected signup details from the final step of the provider wizard to the backend

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4f334d88832899d35b50a17358b1